### PR TITLE
fix(git): suppress default branch name warning

### DIFF
--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -51,3 +51,5 @@
 	clean = git-lfs clean -- %f
 	smudge = git-lfs smudge -- %f
 	process = git-lfs filter-process
+[init]
+	defaultBranch = master


### PR DESCRIPTION
Retain old default behavior for maximum compatibility with scripts
assuming origin/master.