### PR TITLE
feat(nvim): history length of git log based on time

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -178,7 +178,7 @@ command! -nargs=1 RestoreCurPos
 " Fugitive mappings
 nnoremap <leader>gs :G<cr>
 nnoremap <leader>gc :Gcommit<cr>
-nnoremap <leader>gl :RestoreCurPos Silent Gclog -n 20<cr>
+nnoremap <leader>gl :RestoreCurPos Silent Gclog --after='6 months ago'<cr>
 nnoremap <leader>gd :Gdiff<cr>
 nnoremap <leader>ge :RestoreCurPos Gedit<cr>
 nnoremap <leader>gE :RestoreCurPos Gtabedit<cr>


### PR DESCRIPTION
Give enough history for both high and low frequency change files. Time
(6 months ago) might be a better indicator of relevance than a static
count.

A limit is needed in the first place as the performance of the quickfix
list quickly deteriorates with a large number of changes.