### PR TITLE
feat(git): update branch to upstream including submodules

### DIFF
--- a/git/aliases.zsh
+++ b/git/aliases.zsh
@@ -24,7 +24,7 @@ alias gstaa="git stash --include-untracked"
 alias gstaaa="git stash --all"
 alias grm="git rm"
 alias grbu="git rebase @{u}"
-alias gru!="git reset --hard @{u}"
+alias gru!="git reset --hard @{u} && gsmu"
 alias gdt="git difftool"
 alias gmb="git merge-base"
 function delete_gone_local_branches() {


### PR DESCRIPTION
I found myself calling `gru!` almost always followed by `gsmu` in repos
with submodules. Hence, combining both into `gru!`. In a repo without
submodules `gsmu` is a no-op.