### PR TITLE
fix: install / upgrade mac specifics

### DIFF
--- a/bin/dots
+++ b/bin/dots
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -ex
 #
 # dots
 #
@@ -8,9 +8,6 @@ export DOTS=$HOME/.dotfiles
 
 # Set OS X defaults
 $DOTS/osx/set-defaults.sh
-
-# Upgrade homebrew
-brew update
 
 # Install homebrew packages
 $DOTS/homebrew/install.sh 2>&1

--- a/homebrew/install.sh
+++ b/homebrew/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh -ex
 #
 # Homebrew
 #
@@ -18,7 +18,9 @@ then
 fi
 
 # Update all outdates packages
-brew update && brew upgrade `brew outdated`
+brew cleanup
+brew update
+brew upgrade
 
 # Install homebrew packages
 brew install coreutils spark

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -144,7 +144,8 @@ install_dotfiles
 if [ "$(uname -s)" == "Darwin" ]
 then
   info "installing mac specifics\n"
-  if source bin/dots > /tmp/dotfiles-dots 2>&1
+  bash bin/dots
+  if bash bin/dots;
   then
     success "mac specifics installed"
   else


### PR DESCRIPTION
Instead of calling `brew upgrade` with a specific list of outdated items, we leave the determination of outdated stuff up to brew itself. Sometimes on GitHub Actions runners packages like "julia" were outdated. They seemed to have switched from a formula to a cask after they were installed. Hence, providing the name forced brew to try to install "julia" as a package, which no longer existed.