### PR TITLE
ci: switch to macOS 11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-11]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This will become the new "lastest" for macOS on GitHub Actions.