### PR TITLE
fix: install latest (head) nvim on macOS

### DIFF
--- a/common/brew.sh
+++ b/common/brew.sh
@@ -6,6 +6,12 @@ function ensure_brew_installed() {
   fi
 }
 
+function brew_head_install() {
+  ensure_brew_installed
+  brew install --head $1
+  brew upgrade $1
+}
+
 function brew_install() {
   ensure_brew_installed
   # Install and upgrade if already installed

--- a/nvim/install.sh
+++ b/nvim/install.sh
@@ -1,8 +1,10 @@
 #!/bin/bash -ex
 
+source $DOTS/common/brew.sh
+
 if [ "$(uname -s)" = "Darwin" ]; then
   # If this installed version crashes, install from source instead.
-  brew reinstall neovim
+  brew_head_install neovim
 elif [[ "$(lsb_release -i)" == *"Ubuntu"* ]]; then
   # Remove old installs
   sudo snap remove nvim


### PR DESCRIPTION
We also use the latest/nightly on Ubuntu. There is no good reason to
split the configuration between macOS and Ubuntu. We only support HEAD
henceforth.