### PR TITLE
fix(nvim): show all overloads for clangd

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -639,7 +639,7 @@ capabilities = require('cmp_nvim_lsp').update_capabilities(capabilities)
 configs.clangd.setup{root_dir=function(fname)
     return root_pattern(vim.loop.cwd()) or util.path.dirname(fname)
   end,
-  cmd={'clangd', '--background-index', '--compile-commands-dir='..(root_pattern(vim.loop.cwd()) or '')},
+  cmd={'clangd','--completion-style=detailed', '--background-index', '--compile-commands-dir='..(root_pattern(vim.loop.cwd()) or '')},
   capabilities=capabilities,
   on_attach=on_attach
   }


### PR DESCRIPTION
clangd assumes that a client with signature help is also able to deal
with bundled overload sets. This is not the case in nvim (yet).
Therefore, unpack all overload sets and show them one-by-one instead.