### PR TITLE
fix: install missing python3-dev

### DIFF
--- a/common/pip.sh
+++ b/common/pip.sh
@@ -3,7 +3,7 @@ function ensure_pip_installed() {
     if test ! "$(python3 -m pip)"
     then
       source $DOTS/common/apt.sh
-      apt_install --no-install-recommends python3-pip
+      apt_install --no-install-recommends python3-pip python3-dev
     fi
   fi
 }


### PR DESCRIPTION
For example ujson as part of pyls needs to be build for Hirsute. This
requires the python3 development headers.

Fixes: #70