### PR TITLE
feat: install nvim stable with pre-compiled official package

### DIFF
--- a/nvim/install.sh
+++ b/nvim/install.sh
@@ -1,10 +1,21 @@
 #!/bin/bash -ex
 
-source $DOTS/common/brew.sh
-
 if [ "$(uname -s)" = "Darwin" ]; then
-  # If this installed version crashes, install from source instead.
-  brew_head_install neovim
+  tmpfile=$(mktemp)
+  trap "rm -rf ${tmpfile}" EXIT
+  curl -Lo "${tmpfile}" https://github.com/neovim/neovim/releases/download/v0.6.0/nvim-macos.tar.gz
+  expect_hash="03cdbfeec3493f50421a9ae4246abe4f9493715f5e151a79c4db79c5b5a43acc"
+  actual_hash="$(shasum -a 256 ${tmpfile} | cut -d' ' -f 1)"
+  if [[ "$expect_hash" != "$actual_hash" ]]; then
+    echo "shasum mismatch for nvim. Aborting."
+    exit 1
+  fi
+  mkdir -p ~/.nvim
+  tar -C ~/.nvim --extract -z -f "${tmpfile}" --strip-components 1
+
+  # Make freshly installed nvim available in path
+  script_dir=$(dirname $0)
+  . ${script_dir}/path.zsh
 elif [[ "$(lsb_release -i)" == *"Ubuntu"* ]]; then
   # Remove old installs
   sudo snap remove nvim

--- a/nvim/path.zsh
+++ b/nvim/path.zsh
@@ -1,1 +1,1 @@
-export PATH=/snap/bin:$PATH
+export PATH=~/.nvim/bin:/snap/bin:$PATH

--- a/nvim/test.sh
+++ b/nvim/test.sh
@@ -6,6 +6,15 @@ which nvim
 echo "Check if vim alias is set"
 which vim
 
+echo "Check if nvim is user-installed one"
+local actual_path
+actual_path=$(realpath $(which nvim))
+if [[ "${actual_path}" != $(realpath ~/.nvim/bin)* ]]; then
+  echo Actual Path: $actual_path
+  echo Expected to be in ~/.nvim/bin instead
+  exit 1
+fi
+
 echo "Check that plugins are installed"
 nvim --headless -s $DOTS/nvim/tagbar.test.vim
 nvim --headless -s $DOTS/nvim/lsp-clangd.test.vim


### PR DESCRIPTION
Version 0.6 of nvim is released. Therefore, we no longer need to use
a nightly version. Moreover, switch to pre-compiled packages to save
time on macOS testing on GitHub Actions.

Part of #89