### PR TITLE
fix: remove fudging of the system paths

### DIFF
--- a/system/_path.zsh
+++ b/system/_path.zsh
@@ -1,2 +1,3 @@
-export PATH="$DOTS/bin:/usr/local/bin:/usr/local/sbin:$PATH"
-export MANPATH="/usr/local/man:/usr/local/mysql/man:/usr/local/git/man:$MANPATH"
+# This can be used to do a final fudging on the PATH
+# This file is loaded _after_ the initial loop over the path.zsh files.
+export PATH="$DOTS/bin:$PATH"


### PR DESCRIPTION
The final correction of the system path so far set the /usr/local/
paths to the front again. That means that for example a local nvim
install takes precedence over a user-installed nvim in the HOME folder.

That is unexpected. Therefore, only keeping the setting of the DOTS/bin
folder and nothing else.