### PR TITLE
fix!: escape rg integration for nvim command

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -386,7 +386,9 @@ fun! s:Grep(txt)
   else
     let needle =  a:txt
   endif
-  silent! execute "grep! " . shellescape(needle)
+  " Escape full string AND escape vim command mode special chars
+  " Borrowed from mileszs/ack.vim
+  silent! execute "grep! " . shellescape(escape(needle, '|#%'))
 endfun
 
 command! -nargs=* -complete=file Rg :call s:Grep(<q-args>)

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -386,7 +386,7 @@ fun! s:Grep(txt)
   else
     let needle =  a:txt
   endif
-  silent! execute "grep! " . needle
+  silent! execute "grep! " . shellescape(needle)
 endfun
 
 command! -nargs=* -complete=file Rg :call s:Grep(<q-args>)

--- a/nvim/ripgrep.test.vim
+++ b/nvim/ripgrep.test.vim
@@ -1,4 +1,4 @@
-:Rg "\. <<"
+:Rg \. <<
 :call feedkeys("\<cr>", 't')
 :"check correct line
 :if getcurpos()[1] != 2
@@ -9,5 +9,15 @@
 :  cquit!
 :endif
 :"All well
+:"Test space separated searches, i.e., multi word
+:Rg of the
+:cfirst
+:if getcurpos()[1] != 4
+:  cquit!
+:endif
+:"check correct column
+:if getcurpos()[2] != 22
+:  cquit!
+:endif
 :quitall!
 


### PR DESCRIPTION
Allow passing multiple parameters to :Rg without the user needing to
quote them. I.e., make :Rg behave the same way as `/` for searching.

Fixes: #102