### PR TITLE
fix: fix searching with only quickfix window open

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -374,12 +374,6 @@ if executable("rg")
   let &grepformat="%f:%l:%c:%m"
 endif
 
-augroup myvimrc
-    autocmd!
-    autocmd QuickFixCmdPost [^l]* cwindow
-    autocmd QuickFixCmdPost l*    lwindow
-augroup END
-
 fun! s:Grep(txt, bang)
   if empty(a:txt)
     let needle = expand("<cword>")
@@ -395,6 +389,7 @@ fun! s:Grep(txt, bang)
     let needle = shellescape(needle)
   endif
   silent! execute "grep! " . needle
+  copen
 endfun
 
 command! -bang -nargs=* -complete=file Rg :call s:Grep(<q-args>, '<bang>')


### PR DESCRIPTION
The removed autocmd group interfered with the scenario where only the
quickfix window was open. Since the definition of the autocommand group
was a little to indiscriminate, let's remove and replace it by a simple
invocation of :copen at the end of our search function.

Most importantly: This changes the behavior of an empty search. The
quickfix window will now no longer close. Instead, it will remain open
and be empty.

Part of #117