### PR TITLE
ci: remove outdated optimization that is now a pessimization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,6 @@ jobs:
           # updated for autojump.
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
           cd .dotfiles/
-          if [[ "${{ matrix.os }}" == macos* ]]; then
-            # Remove a download bandwidth hog often installed on GitHub runners
-            brew remove azure-cli || true;
-          fi
           ./script/bootstrap
           ./script/install
           ./script/test


### PR DESCRIPTION
After the introduction of HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK, the
explicitly removal of azure-cli to avoid udpating it as a dependency is
no longer necessary. Some runs spend more than 4 minutes on removing
this dependency for no good reason.

Part of #122