### PR TITLE
fix: macOS specific installation

### DIFF
--- a/osx/set-defaults.sh
+++ b/osx/set-defaults.sh
@@ -20,7 +20,7 @@ defaults write com.apple.NetworkBrowser BrowseAllInterfaces 1
 defaults write com.apple.Finder FXPreferredViewStyle Nlsv
 
 # Show the ~/Library folder.
-chflags nohidden ~/Library
+chflags nohidden ~/Library || true
 
 # Set a really fast key repeat.
 defaults write NSGlobalDomain KeyRepeat -int 0

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -150,6 +150,7 @@ then
     success "mac specifics installed"
   else
     fail "error installing mac specifics"
+    exit 1
   fi
 fi
 


### PR DESCRIPTION
Allow to fail for chflags and convert all other failures into a hard
fail.

Fixes: #134