### PR TITLE
fix: no explicit homebrew update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
           # Otherwise, this might update node or php if for example sqlite3 is
           # updated for autojump.
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+          export HOMEBREW_NO_INSTALL_CLEANUP=1
           cd .dotfiles/
           ./script/bootstrap
           ./script/install

--- a/script/install
+++ b/script/install
@@ -11,17 +11,8 @@ if [[ "$(uname)" == "Linux" && "$(lsb_release -i)" == *"Ubuntu"* ]]; then
   sudo apt-get update
 fi
 
-if [ "$(uname -s)" == "Darwin" ]; then
-  # We only want our explicit cleanup when multiple installers run
-  export HOMEBREW_NO_INSTALL_CLEANUP=1
-
-  source "$DOTS/common/brew.sh"
-
-  ensure_brew_installed
-
-  brew cleanup
-  brew update
-fi
+# No explicit update for homebrew, there are enough update and cleanup
+# invocations automatically after a certain time has passed.
 
 # find the installers and run them iteratively
 installers=$(find . -name install.sh)


### PR DESCRIPTION
Instead, rely on the 30 days cleanup
(HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS) and on CI hope that someone else
updates from time to time as we disable the update of homebrew for CI
explicitly. For local runs, this remains unaffected.

This has all been done in the chase of a faster CI time for macOS
builds in #122.