### PR TITLE
test: add test for zsh user input

### DIFF
--- a/zsh/install.sh
+++ b/zsh/install.sh
@@ -10,7 +10,8 @@ if [ "$(uname -s)" = "Darwin" ]; then
   brew_install zsh
 elif [[ "$(lsb_release -i)" == *"Ubuntu"* ]]; then
   source "$DOTS/common/apt.sh"
-  apt_install zsh
+  # Install 'expect' for testing
+  apt_install zsh expect
 fi
 
 if [ -d "$checkout_path" ]; then

--- a/zsh/test.sh
+++ b/zsh/test.sh
@@ -2,5 +2,11 @@
 # shellcheck shell=bash
 set -ex
 
+echo "Test that start up and basic user input to shell work without errors"
+# This was added after a faulty linter change led to printing the following on all key presses
+# sh:1: url-quote-magic: function definition file not found
+$DOTS/zsh/userinput.test.expect
+
+
 echo "Check if startup is sufficiently fast"
 measure-runtime.py --repeat=10 --expected-ms 275 zsh -i -c 'exit'

--- a/zsh/userinput.test.expect
+++ b/zsh/userinput.test.expect
@@ -1,0 +1,24 @@
+#!/usr/bin/expect
+#set timeout 1
+
+spawn zsh "-ie";
+expect "➜";
+send "echo test\r";
+
+# End the program with ctrl-d
+send "\x04";
+
+expect eof;
+
+foreach {pid spawnid os_error_flag value} [wait] break;
+if {$os_error_flag == 0} {
+    puts "exit status: $value"
+    exit $value
+} else {
+    puts "errno: $value"
+    exit $value
+}
+EOF
+echo "spawned process status" $?
+rm -f $tmp_script_file
+echo "done"

--- a/zsh/userinput.test.expect
+++ b/zsh/userinput.test.expect
@@ -3,6 +3,11 @@
 
 spawn zsh "-ie";
 expect "➜";
+
+# Clear up input with ctrl-c
+send "\x03";
+expect "➜";
+
 send "echo test\r";
 
 # End the program with ctrl-d


### PR DESCRIPTION
After a faulty shell linting session, each keypress led to printing out
an error. To prevent recurrence, add this test.