### PR TITLE
fix: remove outdated snap path for nvim

### DIFF
--- a/nvim/path.zsh
+++ b/nvim/path.zsh
@@ -1,1 +1,1 @@
-export PATH=~/.nvim/bin:/snap/bin:$PATH
+export PATH=~/.nvim/bin:$PATH


### PR DESCRIPTION
After migrating to a user-installed nvim, the snap path is no longer
necessary.