### PR TITLE
ci: shellcheck all scripts together

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ jobs:
         uses: ludeeus/action-shellcheck@master
         with:
           severity: warning
+          # Prevent SC1090/SC1091. Will fail if we have too many scripts.
+          # Check usage of "-x" or "external-sources=true" then.
+          check_together: 'yes'
         env:
           SHELLCHECK_OPTS: -s bash
 

--- a/script/check_for_upgrade.sh
+++ b/script/check_for_upgrade.sh
@@ -29,7 +29,6 @@ fi
 
 if [ -f ~/.dots-update ]
 then
-  # shellcheck disable=SC1090
   . ~/.dots-update
 
   if [[ -z "$LAST_EPOCH" ]]; then

--- a/virtualenvwrapper/workon.zsh
+++ b/virtualenvwrapper/workon.zsh
@@ -8,10 +8,8 @@ macos_virtualenv_scripts=/usr/local/bin
 ubuntu_virtualenv_scripts=/usr/share/virtualenvwrapper
 lazy_wrapper=virtualenvwrapper_lazy.sh
 if [ -f "${macos_virtualenv_scripts}/${lazy_wrapper}" ]; then
-  # shellcheck disable=SC1090
   source "${macos_virtualenv_scripts}/${lazy_wrapper}"
 elif [ -f "${ubuntu_virtualenv_scripts}/${lazy_wrapper}" ]; then
-  # shellcheck disable=SC1090
   source "${ubuntu_virtualenv_scripts}/${lazy_wrapper}"
 else
   echo -e "Could not find virtualenvwrapper_lazy"


### PR DESCRIPTION
This allows shellcheck to follow included files correctly.