### PR TITLE
chore: remove unused relink script instead of fixing it

### DIFF
--- a/homebrew/relink.zsh
+++ b/homebrew/relink.zsh
@@ -1,9 +1,0 @@
-#!/usr/bin/env zsh
-
-function brew-relink-all() {
-  ls -1 /usr/local/Library/LinkedKegs | while read line; do
-      echo $line
-      brew unlink $line
-      brew link --force $line
-  done
-}


### PR DESCRIPTION
The LinkedKegs folder is not even available anymore.