### PR TITLE
test: make userinput zsh test more stable

### DIFF
--- a/zsh/userinput.test.expect
+++ b/zsh/userinput.test.expect
@@ -1,5 +1,4 @@
 #!/usr/bin/expect
-#set timeout 10
 
 spawn zsh "-ie";
 expect "➜";

--- a/zsh/userinput.test.expect
+++ b/zsh/userinput.test.expect
@@ -1,12 +1,11 @@
 #!/usr/bin/expect
-#set timeout 1
+#set timeout 10
 
 spawn zsh "-ie";
 expect "➜";
 
-# Clear up input with ctrl-c
-send "\x03";
-expect "➜";
+# Clear up input with ctrl-w
+send "\x17";
 
 send "echo test\r";
 


### PR DESCRIPTION
Instead of using ctrl-c to clear up previous erroneous input (only
appears on Github Actions Ubuntu runner), use ctrl-w. This was
necessary as the test failed local execution.