### PR TITLE
feat: do not wrap on search

### DIFF
--- a/nvim/completion.test.vim
+++ b/nvim/completion.test.vim
@@ -12,6 +12,7 @@
 :  redraw
 :  echomsg "Sending <esc> to finalize selection"
 :  call feedkeys("\<esc>")
+:  call cursor(1,1)
 :  let inline_keyword_found = search('inline')
 :  if inline_keyword_found != 0
 :    echomsg "Found expected completion in text"
@@ -36,4 +37,4 @@
 :endfunction
 
 :call timer_start(500, funcref("SelectIt"))
-:call feedkeys("iin", 'tx!')
+:call feedkeys("i in", 'tx!')

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -21,6 +21,9 @@ set noshowmode
 " Allow switching to other buffer without saving
 set hidden
 
+" Do not wrap on search in order to not miss reaching the end of matches
+set nowrapscan
+
 filetype off
 
 " Specify a directory for plugins


### PR DESCRIPTION
Such that reaching the end/start of a document with no further matches
becomes conspicuous.

Fixes #105