### PR TITLE
perf: increase zsh startup expectation to 300 ms

### DIFF
--- a/zsh/test.sh
+++ b/zsh/test.sh
@@ -8,4 +8,4 @@ expect -c "strace 4" "$DOTS/zsh/userinput.test.expect"
 
 
 echo "Check if startup is sufficiently fast"
-measure-runtime.py --repeat=10 --expected-ms 275 zsh -i -c 'exit'
+measure-runtime.py --repeat=10 --expected-ms 300 zsh -i -c 'exit'


### PR DESCRIPTION
The signal-to-noise ratio is too low right now. Therefore, raising the
expectation to still catch vast outliers but to also not be broken for
singular start up problems on a CI with noisy neighbours.

Part of #170