### PR TITLE
ci: always run ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,12 @@
 name: Test dotfiles
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
-    - master
+      - master
 jobs:
   lint:
       runs-on: ubuntu-latest


### PR DESCRIPTION
We want concurrent pull requests to be allowed. For this, we need the
CI to run on the master branch as well.