### PR TITLE
fix(nvim): remove nocompatible from nvim config

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -1,4 +1,3 @@
-set nocompatible
 set modelines=1
 
 let g:loaded_python_provider = 0


### PR DESCRIPTION
nvim is always `nocompatible`.