### PR TITLE
fix: remove autojump explicitly

### DIFF
--- a/common/apt.sh
+++ b/common/apt.sh
@@ -4,3 +4,7 @@ set -e
 function apt_install() {
   sudo apt-get install --upgrade -y "$@"
 }
+
+function apt_remove() {
+  sudo apt-get remove -y "$@"
+}

--- a/common/brew.sh
+++ b/common/brew.sh
@@ -20,3 +20,8 @@ function brew_install() {
   # Install and upgrade if already installed (this is done by `install` if HOMEBREW_NO_INSTALL_UPGRADE is not set)
   brew install "$@"
 }
+
+function brew_remove() {
+  ensure_brew_installed
+  brew remove "$@"
+}

--- a/common/brew.sh
+++ b/common/brew.sh
@@ -23,5 +23,5 @@ function brew_install() {
 
 function brew_remove() {
   ensure_brew_installed
-  brew remove "$@"
+  brew remove -f "$@"
 }

--- a/zoxide/install.sh
+++ b/zoxide/install.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
+#!/bin/bash
 set -ex
+
+# Remove old autojump installation.
+# Otherwise old "j" compdef might still be sourced and conflicts with the zoxide definition.
+if [ "$(uname -s)" = "Darwin" ]; then
+  source "$DOTS/common/brew.sh"
+  brew_remove autojump
+elif [[ "$(lsb_release -i)" == *"Ubuntu"* ]]; then
+  source "$DOTS/common/apt.sh"
+  apt_remove autojump
+fi
 
 if [ "$(uname -s)" = "Darwin" ]; then
   download_url="https://github.com/ajeetdsouza/zoxide/releases/download/v0.8.0/zoxide-v0.8.0-x86_64-apple-darwin.tar.gz"


### PR DESCRIPTION
Without the explicit removal, there might still be compdef definitions
that conflict with zoxide's 'j'.

Fixes #207