### PR TITLE
fix(osx): set default key repeat to fastest value available in UI

### DIFF
--- a/osx/set-defaults.sh
+++ b/osx/set-defaults.sh
@@ -23,7 +23,7 @@ defaults write com.apple.Finder FXPreferredViewStyle Nlsv
 chflags nohidden ~/Library || true
 
 # Set a really fast key repeat.
-defaults write NSGlobalDomain KeyRepeat -int 0
+defaults write NSGlobalDomain KeyRepeat -int 2
 
 # Set the Finder prefs for showing a few different volumes on the Desktop.
 defaults write com.apple.finder ShowExternalHardDrivesOnDesktop -bool true


### PR DESCRIPTION
When using the keyboard preferences in OSX, the value "2" is the
fastest setting. Setting it to "0" will increase it too a much too high
value. This is obstructing using j/k keys for scrolling line by line in
a sensible way.