### PR TITLE
fix(nvim): detect remote default git branch

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -201,7 +201,7 @@ command! -nargs=1 RestoreCurPos
       \ | call setpos('.', save_cursor)
 
 function s:diff_to_default_branch()
-  let defaultbranch = s:get_default_branch()
+  let defaultbranch = Get_default_branch()
   exe 'Gdiffsplit ' . defaultbranch
 endfunction
 
@@ -477,21 +477,27 @@ let g:dispatch_handlers = [
       \ 'headless',
       \ ]
 
-function! s:get_default_branch() abort
+function! Get_default_branch() abort
   " Source: https://stackoverflow.com/questions/28666357/git-how-to-get-default-branch
   " let defaultbranch = execute("Git symbolic-ref refs/remotes/origin/HEAD")
   let defaultbranch = split(execute('Git rev-parse --abbrev-ref origin/HEAD'), "\n")[0]
-  if defaultbranch =~? 'fatal: .*'
+  let output = execute('Git rev-parse --abbrev-ref origin/HEAD')
+  if output =~? '.*fatal: .*'
     echohl WarningMsg
-    echom 'Using default origin/master, no symbolic-ref for refs/remotes/origin/HEAD found.'
+    echom 'Could not detect default branch, using origin/master.'
+    echom 'Maybe .git/refs/remotes/origin/HEAD is missing as this repo has not been cloned?'
+    echom 'Set symbolic ref manually: git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master.'
+    echom 'Using default origin/master.'
+    let defaultbranch = 'origin/master'
     echohl None
+  else
+    let defaultbranch = split(output, "\n")[0]
   endif
-  let defaultbranch = 'origin/master'
   return defaultbranch
 endfunction
 
 function! s:get_diff_file_master_merge() abort
-  let defaultbranch = s:get_default_branch()
+  let defaultbranch = Get_default_branch()
   let common_revision = split(execute('Git merge-base ' . defaultbranch . ' HEAD'), "\n")[0]
   return common_revision
 endfunction

--- a/nvim/test.sh
+++ b/nvim/test.sh
@@ -51,10 +51,10 @@ cdtmp
 mkdir "source"
 cd "source"
 git init
-git branch -M specialdefault
 touch a
 git add a
 git commit -m 'test'
+git branch -M specialdefault
 cd ..
 git clone "source" "target"
 cd target
@@ -70,10 +70,10 @@ cdtmp
 mkdir "source"
 cd "source"
 git init
-git branch -M specialdefault
 touch a
 git add a
 git commit -m 'test'
+git branch -M specialdefault
 cd ..
 mkdir modules
 cd modules

--- a/nvim/test.sh
+++ b/nvim/test.sh
@@ -81,9 +81,7 @@ git init
 git submodule add ../source
 git commit -m 'test'
 # pwd == main repo but open file in submodule
-# TODO(kaihowl) remove
-stat source/a
-output=$(nvim "source/a" --headless -c "echo Get_default_branch()" -c 'quit' 2>&1)
+output=$(nvim --headless -c "edit source/a" -c "echo Get_default_branch()" -c 'quit' 2>&1)
 if [[ "$output" != *"origin/specialdefault" ]]; then
   echo "Detected wrong default branch, should have been origin/specialdefault but was"
   echo "$output"

--- a/nvim/test.sh
+++ b/nvim/test.sh
@@ -17,7 +17,7 @@ fi
 
 echo "Check that all test scripts are called afterwards in this script"
 found_tests=$(find "$(realpath "$(dirname "$0")")" -name '*.test.vim' | wc -l)
-registered_tests=$(($(grep -c 'nvim --headless' "$0") - 1))
+registered_tests=$(grep -c '\-s .*\.test\.vim' "$0")
 if [[ found_tests -ne registered_tests ]]; then
   echo "Expected number of tests: ${found_tests}"
   echo "Actual number of tests: ${registered_tests}"
@@ -36,6 +36,57 @@ nvim --headless -s "$DOTS/nvim/nvim-cmp-select-enter.test.vim"
 cd "$DOTS/test-editorconfig/" && nvim --headless -s "$DOTS/nvim/editorconfig.test.vim"
 cd "$DOTS/nvim/test-ripgrep/" && nvim --headless -s "$DOTS/nvim/ripgrep.test.vim"
 cd "$DOTS/nvim/test-efm/" && nvim --headless -s "$DOTS/nvim/lsp-efm.test.vim"
+
+echo "Check that git default folder detection works with a default"
+cd "$DOTS/"
+output=$(nvim --headless -c "echo Get_default_branch()" -c 'quit' 2>&1)
+if [[ "$output" != *"origin/master" ]]; then
+  echo "Detected wrong default branch, should have been origin/master but was"
+  echo "$output"
+  exit 1
+fi
+
+echo "Check that git default folder detection works"
+cdtmp
+mkdir "source"
+cd "source"
+git init
+git branch -M specialdefault
+touch a
+git add a
+git commit -m 'test'
+cd ..
+git clone "source" "target"
+cd target
+output=$(nvim --headless -c "echo Get_default_branch()" -c 'quit' 2>&1)
+if [[ "$output" != *"origin/specialdefault" ]]; then
+  echo "Detected wrong default branch, should have been origin/specialdefault but was"
+  echo "$output"
+  exit 1
+fi
+
+echo "Check that git default folder detection works with submodules"
+cdtmp
+mkdir "source"
+cd "source"
+git init
+git branch -M specialdefault
+touch a
+git add a
+git commit -m 'test'
+cd ..
+mkdir modules
+cd modules
+git init
+git submodule add ../source
+git commit -m 'test'
+# pwd == main repo but open file in submodule
+output=$(nvim "source/a" --headless -c "echo Get_default_branch()" -c 'quit' 2>&1)
+if [[ "$output" != *"origin/specialdefault" ]]; then
+  echo "Detected wrong default branch, should have been origin/specialdefault but was"
+  echo "$output"
+  exit 1
+fi
 
 echo "Check if startup is sufficiently fast"
 measure-runtime.py --repeat=10 --expected-ms 250 nvim +qall

--- a/nvim/test.sh
+++ b/nvim/test.sh
@@ -81,10 +81,9 @@ git init
 git submodule add ../source
 git commit -m 'test'
 # pwd == main repo but open file in submodule
-# TODO(kaihowl) wrong pwd
+# TODO(kaihowl) remove
 stat source/a
-cd source/
-output=$(nvim "a" --headless -c "echo Get_default_branch()" -c 'quit' 2>&1)
+output=$(nvim "source/a" --headless -c "echo Get_default_branch()" -c 'quit' 2>&1)
 if [[ "$output" != *"origin/specialdefault" ]]; then
   echo "Detected wrong default branch, should have been origin/specialdefault but was"
   echo "$output"

--- a/nvim/test.sh
+++ b/nvim/test.sh
@@ -81,7 +81,10 @@ git init
 git submodule add ../source
 git commit -m 'test'
 # pwd == main repo but open file in submodule
-output=$(nvim "source/a" --headless -c "echo Get_default_branch()" -c 'quit' 2>&1)
+# TODO(kaihowl) wrong pwd
+stat source/a
+cd source/
+output=$(nvim "a" --headless -c "echo Get_default_branch()" -c 'quit' 2>&1)
 if [[ "$output" != *"origin/specialdefault" ]]; then
   echo "Detected wrong default branch, should have been origin/specialdefault but was"
   echo "$output"


### PR DESCRIPTION
This was broken in earlier commits to enable submodule support.

Fixes #236