### PR TITLE
feat(nvim): verbose fetch

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -231,7 +231,7 @@ nnoremap <leader>g3 :RestoreCurPos Gedit :3<cr>:Gdiff :1<cr>
 " Fugitive git push / fetch mappings
 nnoremap <leader>gp :Git! push<cr>
 nnoremap <leader>gP :Git! pub<cr>
-nnoremap <leader>gf :Git! fetch<cr>
+nnoremap <leader>gf :Git! fetch --verbose<cr>
 
 augroup nolist_filtypes
   autocmd!


### PR DESCRIPTION
With streaming input into the preview window, a hanging git-fetch is
indistinguishable from a finished but empty git-fetch.

Hack around this by making git-fetch verbose.