### PR TITLE
feat: minimal asynctasks status indicator

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -600,6 +600,7 @@ set statusline+=\[%{&fileformat}\]
 set statusline+=\ %p%%
 set statusline+=\ %l:%c
 set statusline+=\ 
+set statusline+=\ %{g:asyncrun_status[0:0]}
 " -----
 
 " Make nerdtree work like vim-vinegar


### PR DESCRIPTION
Right screen single letter in status line for [s]uccess, [f]ailure, and
[r]unning.

Fixes #253