### PR TITLE
fix: allow git-zlog to ignore releases when 'since' is specified

### DIFF
--- a/bin/git-zlog
+++ b/bin/git-zlog
@@ -439,7 +439,7 @@ function main {
     body="${raw_fields[4]}"
 
     # If we find a new release (exact tag)
-    if [[ "$refs" = *tag:\ * ]]; then
+    if [[ -z "$since" ]] && [[ "$refs" = *tag:\ * ]]; then
       # Parse tag name (needs: setopt extendedglob)
       tag="${${refs##*tag: }%%,# *}"
       # Output previous release


### PR DESCRIPTION
This allows to use git-zlog to show differences for commit range
updates when fetching.

Fixes #267