### PR TITLE
feat(nvim): keep right for long file names when switching buffers

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -295,7 +295,7 @@ endfunction
 command! BUFFERS call fzf#run(
   \ fzf#wrap({
   \ 'source': map(sort(filter(range(1, bufnr('$')),{pos,val -> s:FilterBuffer(val)}), 's:CompBufferLastUsed'), {pos,val -> s:FormatBuffer(val)}),
-  \ 'options': '--no-sort',
+  \ 'options': '--no-sort --keep-right',
   \ 'sink': 'b'
   \}))
 nnoremap <silent> <leader>d :BUFFERS<cr>


### PR DESCRIPTION
Fixes #271