### PR TITLE
fix(nvim): only source filetype.vim once

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -24,14 +24,7 @@ set hidden
 " Do not wrap on search in order to not miss reaching the end of matches
 set nowrapscan
 
-filetype off
-
-syntax enable
-
 set tabstop=2 softtabstop=2 shiftwidth=2 expandtab shiftround
-
-" Wrap gitcommit file types at the appropriate length
-filetype indent plugin on
 
 set wildignore+=*/node_modules/*,*.aux,*.d,*.o,*.pyc
 set wildignorecase
@@ -159,6 +152,7 @@ Plug 'kaihowl/asyncrun.vim', { 'branch': 'use-qf-id' }
 
 Plug 'ibhagwan/fzf-lua'
 
+" the plug#end automatically calls "filetype plugin indent on" and "syntax enable"
 call plug#end()
 " }}}
 


### PR DESCRIPTION
The previous gymnastics of calling `filetype off` and `filetype indent
plugin on` were only needed in Pathogen. I seem to have copied this
over when starting a fresh vimrc by using stevelosh's defaults.

With using Plug as the plugin manager instead, the filetype and syntax
enabling is handled already.

Removing the superfluous commands removes sourcing of ftoff and an
additional sourcing of filetype.vim. This saves about 10 ms of start up
time overall.