### PR TITLE
fix(nvim): fix sporadic output errors in fzf-lua files

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -271,6 +271,7 @@ require('fzf-lua').setup{
      ['--history']     = vim.g.fzf_history_dir .. '/' .. 'history'
   },
   files = {
+    rg_opts = '--hidden --files --color=never --glob ""',
     winopts = {
       preview = {
         hidden = 'hidden',


### PR DESCRIPTION
Do not follow symlinks (that are potentially broken). Reuse the
original arguments used for rg before fzf / fzf-lua replaced ctrlp.