### PR TITLE
fix(nvim): do not error on missing fzf-lua module when installing

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,2 +1,0 @@
-- fzf history missing
-- ensure that no errors appear on initial bootstrap

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -619,7 +619,9 @@ set statusline+=\[%{&fileformat}\]
 set statusline+=\ %p%%
 set statusline+=\ %l:%c
 set statusline+=\ 
-set statusline+=\ %{g:asyncrun_status[0:0]}
+if !exists('g:first_time_startup')
+  set statusline+=\ %{g:asyncrun_status[0:0]}
+endif
 "}}}
 
 "{{{ NerdTree

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -260,6 +260,7 @@ if !isdirectory(g:fzf_history_dir)
   call mkdir(g:fzf_history_dir, 'p')
 endif
 
+if !exists('g:first_time_startup')
 lua <<EOF
 require('fzf-lua').setup{
   winopts = {
@@ -292,6 +293,7 @@ require('fzf-lua').setup{
   }
 }
 EOF
+endif
 
 nnoremap <leader>s :FzfLua files<cr>
 nnoremap <leader>d :FzfLua buffers<cr>


### PR DESCRIPTION
Moreover, remove outdated TODO file.