### PR TITLE
perf(nvim): do not use range context for git-log per default

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -213,8 +213,8 @@ endfunction
 
 " Fugitive mappings
 nnoremap <leader>gs :G<cr>
-nnoremap <leader>gl :RestoreCurPos Silent %Gclog --after='6 months ago'<cr>
-nnoremap <leader>gL :RestoreCurPos Silent %Gclog<cr>
+nnoremap <leader>gl :RestoreCurPos Silent 0Gclog --after='6 months ago'<cr>
+nnoremap <leader>gL :RestoreCurPos Silent 0Gclog<cr>
 nnoremap <leader>gd :Gdiff<cr>
 nnoremap <leader>gm :call <sid>diff_to_default_branch()<cr>
 nnoremap <leader>ge :RestoreCurPos Gedit<cr>


### PR DESCRIPTION
To just browse through the history of a single file, the range given to
the Gclog command should not contain the entire file. This
unnecessarily slows down both the git command as well as the quickfix
parsing of the output: The entire file for each revision is parsed.

Instead, pass a zero context to the Gclog command.

This was erroneously introduced in 7c668d8.

Fixes #283.