### PR TITLE
fix(nvim): do not restore cursor position for git-log

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -213,8 +213,8 @@ endfunction
 
 " Fugitive mappings
 nnoremap <leader>gs :G<cr>
-nnoremap <leader>gl :RestoreCurPos Silent 0Gclog --after='6 months ago'<cr>
-nnoremap <leader>gL :RestoreCurPos Silent 0Gclog<cr>
+nnoremap <leader>gl :0Gclog --after='6 months ago'<cr>
+nnoremap <leader>gL :0Gclog<cr>
 nnoremap <leader>gd :Gdiff<cr>
 nnoremap <leader>gm :call <sid>diff_to_default_branch()<cr>
 nnoremap <leader>ge :RestoreCurPos Gedit<cr>


### PR DESCRIPTION
For a simple git-log, restoring of the cursor will work for a single
file and single revision. As soon as I jump to the next file in the
quickfix list, the cursor position is gone.

If I want to restrict the git log to a specific set of lines, there is
a visual git log mapping that is superior. I will use that.

This commit removes the unnecessary wrapping of the git log Gclog
invocation in the RestoreCurPos.