### PR TITLE
fix(nvim): ensure unattended vim-plug update and clean

### DIFF
--- a/nvim/install.sh
+++ b/nvim/install.sh
@@ -36,4 +36,4 @@ if [ ! -d "$plug_dir" ]; then
   curl -fLo "${plug_dir}" --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 fi
 
-nvim -u NONE --headless -c 'let g:first_time_startup=1' -c 'source ~/.config/nvim/init.vim' +PlugUpgrade +PlugClean +PlugUpdate +qall
+nvim -u NONE --headless -c 'let g:first_time_startup=1' -c 'source ~/.config/nvim/init.vim' +PlugUpgrade '+PlugClean!' '+PlugUpdate!' +qall


### PR DESCRIPTION
Otherwise, on a non-fresh system the clean / upgrade might fail since
the prompts asking for confirmation do not work in headless mode.