### PR TITLE
feat(tmux): use brightblue for statusline

### DIFF
--- a/tmux/statusline.conf
+++ b/tmux/statusline.conf
@@ -1,17 +1,17 @@
 set -g status-justify "left"
 set -g status "on"
 set -g status-style "none,bg=terminal"
-set -g status-left-style "fg=black,bg=blue"
+set -g status-left-style "fg=black,bg=brightblue"
 set -g status-right-style ""
 set -g status-right-length "100"
 set -g status-left-length "100"
 set -g status-left " #S #[none,bg=terminal] "
-set -g status-right " %Y-%m-%d %a %H:%M #[fg=black,bg=blue] #h "
+set -g status-right " %Y-%m-%d %a %H:%M #[fg=black,bg=brightblue] #h "
 
 set -g message-style "reverse"
 set -g message-command-style "reverse,dim"
 
-set -g pane-active-border-style "fg=blue"
+set -g pane-active-border-style "fg=brightblue"
 set -g pane-border-style "fg=white"
 set -g pane-border-lines "heavy"
 


### PR DESCRIPTION
This increases compatibility with vim color schemes edge/gruvbox which
use the same color for PmenuSel highlights. The bright blue is easier
on the contrast.