### PR TITLE
fix(tmux): remove invalid, too new option

### DIFF
--- a/tmux/statusline.conf
+++ b/tmux/statusline.conf
@@ -13,8 +13,6 @@ set -g message-command-style "reverse,dim"
 
 set -g pane-active-border-style "fg=brightblue"
 set -g pane-border-style "fg=white"
-# Issue #310
-# set -g pane-border-lines "heavy"
 
 setw -g monitor-activity on
 setw -g window-status-activity-style "fg=red"


### PR DESCRIPTION
I don't really need thick borders for tmux. Hence, remove the option
that is only available in newer tmux versions.

Fixes #310