### PR TITLE
fix(zsh): add missing compinit

### DIFF
--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -54,6 +54,10 @@ do
   source $file
 done
 
+# initialize autocomplete here, otherwise functions won't be loaded
+autoload -U compinit
+compinit
+
 unset config_files
 
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh


### PR DESCRIPTION
Without it, user-defined completions will not be present.