### PR TITLE
perf(zsh): do not call compinit twice

### DIFF
--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -24,9 +24,6 @@ fi
 # Periodically (typically once a day), update from github
 source $DOTS/script/check_for_upgrade.sh
 
-# First, load oh-my-zsh
-source $DOTS/zsh/oh-my.zsh.preamble
-
 # your project folder that we can `c [tab]` to
 export PROJECTS=~/Documents/repos/
 
@@ -54,13 +51,12 @@ do
   source $file
 done
 
-# initialize autocomplete here, otherwise functions won't be loaded
-autoload -U compinit
-compinit
-
 unset config_files
 
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
+
+# Last, load oh-my-zsh (which does compinit)
+source $DOTS/zsh/oh-my.zsh.preamble
 
 # We don't want this and oh-my-zsh has no way to turn it off
 # Hence, we brute-force this back


### PR DESCRIPTION
Partially helps with #170 

Current master as a 60 ms regression. This fixes about 30 ms of that regression. Without breaking the possibility of adding custom completions in my dotfiles, I cannot simply revert to the original. Currently though, there are no custom completions taking advantage of this.