### PR TITLE
perf(zsh): selectively add fpath instead of globally

### DIFF
--- a/zsh/fpath.zsh
+++ b/zsh/fpath.zsh
@@ -1,3 +1,0 @@
-#add each topic folder to fpath so that they can add functions and completion scripts
-# shellcheck disable=SC2206
-fpath=($DOTS/* $fpath)


### PR DESCRIPTION
Scanning directories that do not contain additional functions decreases
performance unnecessarily.

Fixes #170