### PR TITLE
fix(zsh): fpath initialization order

### DIFF
--- a/fzf/test.sh
+++ b/fzf/test.sh
@@ -4,3 +4,6 @@ set -x
 
 echo "Checking whether fzf is on path"
 which fzf
+
+echo "Check that ctrl-xo is registered"
+bindkey | grep -i '\^X\^O'

--- a/zoxide/completion.zsh
+++ b/zoxide/completion.zsh
@@ -1,0 +1,3 @@
+# shellcheck disable=SC2206
+fpath=(~/.zoxide/completions $fpath)
+

--- a/zoxide/path.zsh
+++ b/zoxide/path.zsh
@@ -1,4 +1,2 @@
-# shellcheck disable=SC2206
-fpath=(~/.zoxide/completions $fpath)
 export PATH=~/.zoxide:$PATH
 

--- a/zoxide/test.sh
+++ b/zoxide/test.sh
@@ -21,6 +21,12 @@ if [[ "${man_page}" != $(realpath ~/.zoxide/man)* ]]; then
   exit 1
 fi
 
+echo "Check if zoxide completion is available"
+if ! ((${+_comps[zoxide]})); then
+  echo "Missing zoxide zsh completion, fpath set up?"
+  exit 1
+fi
+
 echo "Check zoxide behavior"
 my_dir=$(mktemp -d)
 export _ZO_DATA_DIR=$my_dir

--- a/zsh/test.sh
+++ b/zsh/test.sh
@@ -6,6 +6,8 @@ echo "Test that start up and basic user input to shell work without errors"
 # sh:1: url-quote-magic: function definition file not found
 expect -c "strace 4" "$DOTS/zsh/userinput.test.expect"
 
+echo "Check that ctrl-z is registered"
+bindkey | grep -i '\^Z'
 
 echo "Check if startup is sufficiently fast"
 measure-runtime.py --repeat=10 --expected-ms 300 zsh -i -c 'exit'

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -24,14 +24,23 @@ fi
 # Periodically (typically once a day), update from github
 source $DOTS/script/check_for_upgrade.sh
 
-# your project folder that we can `c [tab]` to
-export PROJECTS=~/Documents/repos/
-
 # all of our zsh files
 typeset -U config_files
 config_files=($DOTS/**/*.zsh)
 # Remove test scripts
 config_files=(${config_files:#*/nvim/test-*/*})
+
+# load every completion before compinit to set up the fpath
+for file in ${(M)config_files:#*/completion.zsh}
+do
+  source $file
+done
+
+# load oh-my-zsh (which does compinit)
+source $DOTS/zsh/oh-my.zsh.preamble
+
+# your project folder that we can `c [tab]` to
+export PROJECTS=~/Documents/repos/
 
 # load the path files
 for file in ${(M)config_files:#*/path.zsh}
@@ -45,18 +54,9 @@ do
   source $file
 done
 
-# load every completion after autocomplete loads
-for file in ${(M)config_files:#*/completion.zsh}
-do
-  source $file
-done
-
 unset config_files
 
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
-
-# Last, load oh-my-zsh (which does compinit)
-source $DOTS/zsh/oh-my.zsh.preamble
 
 # We don't want this and oh-my-zsh has no way to turn it off
 # Hence, we brute-force this back


### PR DESCRIPTION
First set up fpaths, then call omz to do compinit, then load
customizations on top.

Setting up fpath after omz would require a second compinit call that
leads to constant rewriting of the cache.

Setting up omz last (as was done before this patch) leads to
overwriting our keybindings as `bindkey -v` is called during omz setup.
This will reset all keybindings and initialize the vi-keybindings.

Fixes #324