### PR TITLE
fix(nvim): clean up coloring of statusline

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -603,11 +603,10 @@ endfunction
 "{{{status line
 " source: https://shapeshed.com/vim-statuslines
 set statusline=
-set statusline+=%#Search#
 set statusline+=\ %f
 set statusline+=%m
 set statusline+=%=
-set statusline+=%#CursorColumn#
+set statusline+=%#PmenuSel#
 set statusline+=\ %y
 set statusline+=\ %{&fileencoding?&fileencoding:&encoding}
 set statusline+=\[%{&fileformat}\]


### PR DESCRIPTION
This works more consistently across a range of color schemes.