### PR TITLE
ci: breakfix CI issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: '.dotfiles'
+      - name: Unlink git
+        shell: bash
+        if: ${{ matrix.os == 'macos-11' }}
+        run: |
+          # Make the brew link stage of git install succeed
+          brew unlink git@2.35.1 || true
       - name: Install and test
         shell: bash
         run: |

--- a/zsh/test.sh
+++ b/zsh/test.sh
@@ -10,4 +10,4 @@ echo "Check that ctrl-z is registered"
 bindkey | grep -i '\^Z'
 
 echo "Check if startup is sufficiently fast"
-measure-runtime.py --repeat=10 --expected-ms 300 zsh -i -c 'exit'
+measure-runtime.py --repeat=10 --expected-ms 450 zsh -i -c 'exit'


### PR DESCRIPTION
- Increase zsh performance expectation to account for recent slow down
  (#346).
- Unlink git on macOS such that brew install can succeed (#347).