### PR TITLE
fix(nvim): use built-in highlight groups for asyncrun_status

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -602,10 +602,9 @@ endfunction
 
 "{{{status line
 function! FormattedAsyncRun()
-  let colors = { 'running': 'WarningLine',
-    \'success': 'InfoLine',
-    \'failure': 'ErrorLine'}
-
+  let colors = { 'running': 'Substitute',
+    \'success': 'Title',
+    \'failure': 'ErrorMsg'}
   if g:asyncrun_status ==? ''
     return ''
   endif


### PR DESCRIPTION
This guarantees wider compatibility across color schemes.

Fix #370