### PR TITLE
fix(nvim): apply consistent colors for asynctask across colorschemes

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -606,9 +606,9 @@ endfunction
 
 "{{{status line
 function! FormattedAsyncRun()
-  let colors = { 'running': 'Substitute',
-    \'success': 'Title',
-    \'failure': 'ErrorMsg'}
+  let colors = { 'running': 'DiffText',
+    \'success': 'DiffAdd',
+    \'failure': 'DiffDelete'}
   if g:asyncrun_status ==? ''
     return ''
   endif


### PR DESCRIPTION
'Substitute' is not consistently "yellowish" for signalling a running
task. Try instead with 'DiffText' for a running task, 'DiffDelete'
for a failed task, and 'DiffAdd' for a successful task.