### PR TITLE
fix(script): remove double update of dots file

### DIFF
--- a/script/check_for_upgrade.sh
+++ b/script/check_for_upgrade.sh
@@ -14,8 +14,6 @@ function _update_dots_update() {
 
 function _upgrade_dots() {
   /usr/bin/env DOTS="$DOTS" /bin/zsh "$DOTS/script/upgrade.sh"
-  # update the dots file
-  _update_dots_update
 }
 
 epoch_target=$UPDATE_DOTS_DAYS


### PR DESCRIPTION
The dots file was updated twice (harmless) when an actual upgrade of
the dotfiles took place.