### PR TITLE
feat!(script): automatically run bootstrap/upgrade for new changes

### DIFF
--- a/homebrew/install.sh
+++ b/homebrew/install.sh
@@ -16,6 +16,8 @@ source "$DOTS/common/brew.sh"
 # Install homebrew packages
 brew_install coreutils
 
+brew_install flock
+
 # Install reattach-to-user-namespace
 # This makes sure that tmux + vim is able to use the system clipboard
 brew_install reattach-to-user-namespace

--- a/script/.gitignore
+++ b/script/.gitignore
@@ -1,0 +1,1 @@
+/upgrade.sh.lock

--- a/script/upgrade.sh
+++ b/script/upgrade.sh
@@ -9,8 +9,12 @@ then
   newcommit=$(git rev-parse master)
   if [[ $oldcommit != "$newcommit" ]]; then
     printf '\033[0;34m%s\033[0m\n' 'Dotfiles updated to current version.'
-    printf '\033[0;34m%s\033[0m\n' "Please run $DOTS/script/bootstrap"
-    printf '\033[0;34m%s\033[0m\n' 'You might also have to run script/install.'
+    printf '\033[0;34m%s\033[0m\n' 'Requesting sudo for bootstrap/install.'
+    sudo /bin/true
+    printf '\033[0;34m%s\033[0m\n' "Running bootstrap..."
+    ./script/bootstrap
+    printf '\033[0;34m%s\033[0m\n' 'Running install...'
+    ./script/install
   else
     printf '\033[0;34m%s\033[0m\n' 'No updates found.'
   fi

--- a/zsh/install.sh
+++ b/zsh/install.sh
@@ -29,7 +29,8 @@ if (grep -q '/bin/zsh' /etc/shells) && [[ -x /bin/zsh ]]; then
   if [[ "${CI}" == "true" ]]; then
     echo "Running on CI, not changing log in shell"
   else
-    chsh -s /bin/zsh
+    # Allow for unattended upgrade
+    sudo chsh -s "$(which zsh)" "$(whoami)"
   fi
 fi
 


### PR DESCRIPTION
Prevent concurrent invocations when multiple shells are opened.
Expected flow:
- I open a new shell for the first time on a day.
- Updates to dotfiles are detected.
- I switch to a second new shell.
  -- pending update is detected.
  -- but I can start working on this shell.
  -- first shell continues updating.
- Dotfiles are updated from git.
- Bootstrap is run.
- Install is run.

This change also includes asking for the my sudo upfront and
changes the invocation for chsh to use sudo as well. This way I am
asked only once for the password in case there are changes and an
upgrade has to run.