### PR TITLE
fix(fzf): no double install of zsh

### DIFF
--- a/fzf/install.sh
+++ b/fzf/install.sh
@@ -3,8 +3,10 @@ set -ex
 
 cd "$(dirname "$0")"
 
-# Depends on an installed zsh, otherwise the zsh configuration is not generated
-../zsh/install.sh
+if ! which zsh; then
+  printf '\033[0;31m%s\033[0m\n' 'Please install zsh first.'
+  exit 1
+fi
 
 if [ "$(uname)" == "Darwin" ]; then
   source "$DOTS/common/brew.sh"


### PR DESCRIPTION
Instead of installing zsh for the fzf install, only check if zsh is
available. If not, fail.

This is still a suboptimal solution but it will
- prevent installing zsh and omz twice
- fail loud and clear in case that the script/install order changed and
  fzf is installed before zsh.

Better solution is to define the dependency tree between install
scripts and sort them topologically.