### PR TITLE
fix(nvim): restore colorscheme edge specific options

### DIFF
--- a/colors/change-color
+++ b/colors/change-color
@@ -489,6 +489,10 @@ if [[ $vim_colorscheme = onehalf ]]; then
 fi
 
 cat - > ~/.color/color.vim <<EOF
+let g:edge_enable_italic = 1
+let g:edge_disable_italic_comment = 0
+let g:edge_diagnostic_line_highlight = 1
+let g:edge_better_performance = 1
 colorscheme ${vim_colorscheme}
 set background=${background[-1]}
 EOF


### PR DESCRIPTION
These were lost in 4a0e7fa6.