### PR TITLE
chore(gdb): Remove non-actionable todo

### DIFF
--- a/gdb/install.sh
+++ b/gdb/install.sh
@@ -6,6 +6,7 @@ if [ "$(uname)" == "Darwin" ]; then
   exit 0
 elif [[ "$(lsb_release -i)" == *"Ubuntu"* ]]; then
   source "$DOTS/common/apt.sh"
-  # TODO(kaihowl) this will break if it is a different version used for the standard library
+  # This will break if it is a different version used for the standard library.
+  # We have a test to detect this.
   apt_install clang gdb libstdc++6-10-dbg
 fi


### PR DESCRIPTION
There is no proper virtual package to install the correctly versioned
package for the debug symbols.

I also could not find a way to detect the currently installed version
easily to use that information to choose the right version of the
package for the debug symbols.

Since we have a test, this will fail if we for example update to
a later Ubuntu version.