### PR TITLE
fix(script): always bootstrap and install

### DIFF
--- a/script/upgrade.sh
+++ b/script/upgrade.sh
@@ -9,15 +9,16 @@ then
   newcommit=$(git rev-parse master)
   if [[ $oldcommit != "$newcommit" ]]; then
     printf '\033[0;34m%s\033[0m\n' 'Dotfiles updated to current version.'
-    printf '\033[0;34m%s\033[0m\n' 'Requesting sudo for bootstrap/install.'
-    sudo /usr/bin/true
-    printf '\033[0;34m%s\033[0m\n' "Running bootstrap..."
-    ./script/bootstrap
-    printf '\033[0;34m%s\033[0m\n' 'Running install...'
-    ./script/install
   else
     printf '\033[0;34m%s\033[0m\n' 'No updates found.'
   fi
+
+  printf '\033[0;34m%s\033[0m\n' 'Requesting sudo for bootstrap/install.'
+  sudo /usr/bin/true
+  printf '\033[0;34m%s\033[0m\n' "Running bootstrap..."
+  ./script/bootstrap
+  printf '\033[0;34m%s\033[0m\n' 'Running install...'
+  ./script/install
 
   if ! git --no-pager diff --exit-code master..origin/master > /dev/null; then
     printf '\033[0;31m%s\033[0m\n' 'You have pending, local changes. Use dot-export or push them.'


### PR DESCRIPTION
Even if there is no update to the dotfiles themselves, there might be
dependencies that have updates. We want to ingest them as quickly as
possible. Therefore, unconditionally update.