### PR TITLE
fix(ci): only accept 4 sigma deviations

### DIFF
--- a/script/ci.sh
+++ b/script/ci.sh
@@ -56,11 +56,11 @@ add_measurement ci $CI_DURATION
 publish_measurements
 
 set +e
-git perf audit -n 40 -d 6 -m nvim -s "os=${RUNNER_OS}"
+git perf audit -n 40 -m nvim -s "os=${RUNNER_OS}"
 nvim_exit=$?
-git perf audit -n 40 -d 6 -m zsh -s "os=${RUNNER_OS}"
+git perf audit -n 40 -m zsh -s "os=${RUNNER_OS}"
 zsh_exit=$?
-git perf audit -n 40 -d 6 -m ci -s "os=${RUNNER_OS}"
+git perf audit -n 40 -m ci -s "os=${RUNNER_OS}"
 ci_exit=$?
 set -e
 


### PR DESCRIPTION
We initially accepted 6 sigma deviations as there were too few
measurements to have a more strict (and default) 4 sigma acceptance.

This is a flaw in git-perf and must be fixed there. I.e., if there are
not a minimum number of measurements, accept any measurement.

This change reverts 64307f8 and reintroduced the default 4 sigma
acceptance.