### PR TITLE
fix(gdb): install correct version of debug symbols for Ubuntu 22.04

### DIFF
--- a/gdb/gdbinit.symlink
+++ b/gdb/gdbinit.symlink
@@ -1,4 +1,5 @@
-set environment LD_PRELOAD /usr/lib/x86_64-linux-gnu/debug/libstdc++.so.6
+set environment LD_PRELOAD /usr/lib/x86_64-linux-gnu/debug/libstdc++.so
+add-auto-load-safe-path /usr/lib/x86_64-linux-gnu/debug
 python
 import sys
 sys.path.insert(0, '/usr/share/gcc/python')

--- a/gdb/install.sh
+++ b/gdb/install.sh
@@ -8,5 +8,16 @@ elif [[ "$(lsb_release -i)" == *"Ubuntu"* ]]; then
   source "$DOTS/common/apt.sh"
   # This will break if it is a different version used for the standard library.
   # We have a test to detect this.
-  apt_install clang gdb libstdc++6-10-dbg
+  codename=$(lsb_release -cs)
+  if [[ "$codename" == *"focal"* ]]; then
+    apt_install clang gdb libstdc++6-10-dbg
+  elif [[ "$codename" == *"jammy"* ]]; then
+    apt_install clang gdb libstdc++6-12-dbg
+  else
+    echo "Unsupported Ubuntu version $codename"
+    echo "Maybe the following command will point to the correct version"
+    apt-cache depends libstdc++6 | sed -n "s/.*Replaces: \(.*\)$/\1/p"
+    exit 1
+  fi
+  
 fi

--- a/gdb/test.sh
+++ b/gdb/test.sh
@@ -9,7 +9,7 @@ fi
 cd "$(mktemp -d)"
 
 clang++ -std=c++17 -O0 -g3 -o mytest "${DOTS}/gdb/mytest.cpp"
-gdb -x "${DOTS}/gdb/test.gdb" -ex=quit mytest &> test.log
+gdb --batch -x "${DOTS}/gdb/test.gdb" -ex=quit mytest &> test.log
 if ! grep -F 'std::unordered_map with 1 element = {[2] = "mystuff"}' test.log; then
   echo Failed
   cat test.log


### PR DESCRIPTION
Part of #417