### PR TITLE
fix(pyls): no need to install autopep8 explicitly

### DIFF
--- a/pyls/install.sh
+++ b/pyls/install.sh
@@ -5,4 +5,4 @@ source "$DOTS/common/pip.sh"
 ensure_pip_installed
 
 # Install autopep8 to activate optional source formatting in pyls
-sudo python3 -m pip install --upgrade "python-lsp-server[all]" autopep8
+sudo python3 -m pip install --upgrade "python-lsp-server[all]"


### PR DESCRIPTION
This is included as an optional dependency in python-lsp-server when
specifying `all`. An explicit install of the latest autopep8 can
conflict with the version specified by python-lsp-server.