### PR TITLE
ci: require a minimum of 10 measurements

### DIFF
--- a/script/ci.sh
+++ b/script/ci.sh
@@ -59,11 +59,11 @@ add_measurement ci $CI_DURATION
 publish_measurements
 
 set +e
-git perf audit -n 40 -m nvim -s "os=${RUNNER_OS}"
+git perf audit -n 40 -m nvim -s "os=${RUNNER_OS}" --min-measurements 10
 nvim_exit=$?
-git perf audit -n 40 -m zsh -s "os=${RUNNER_OS}"
+git perf audit -n 40 -m zsh -s "os=${RUNNER_OS}" --min-measurements 10
 zsh_exit=$?
-git perf audit -n 40 -m ci -s "os=${RUNNER_OS}"
+git perf audit -n 40 -m ci -s "os=${RUNNER_OS}" --min-measurements 10
 ci_exit=$?
 set -e
 


### PR DESCRIPTION
This ensures that newly added measurements only start to count for
audit once there are enough measurements to ascertain the stddev.