### PR TITLE
feat(nvim): use stat-style view for PRs

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -578,7 +578,7 @@ command! DiffHistory call s:view_merge_request()
 " https://github.com/tpope/vim-fugitive/issues/132#issuecomment-649516204
 function! s:view_merge_request() abort
   let revision = <sid>get_diff_file_master_merge()
-  execute 'Git difftool ' . revision . '..HEAD --find-renames=50\%'
+  execute 'Git difftool --stat ' . revision . '..HEAD --find-renames=50\%'
   if len(getqflist()) > 0
     call s:diff_current_quickfix_entry()
   endif


### PR DESCRIPTION
This converts to using one-file-per-line view with change stats for the
PR overview of a branch compared to the merge base. The additional
benefit of this view is that moved-but-not-changed files appear as
well.

Fixes #432