### PR TITLE
fix(nvim): do not show trailing whitespace / indent guides on fzf

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -129,7 +129,8 @@ Plug 'tpope/vim-abolish'
 Plug 'christoomey/vim-tmux-navigator'
 
 Plug 'nathanaelkane/vim-indent-guides'
-Plug 'bronson/vim-trailing-whitespace'
+" TODO(kaihowl) #471
+Plug 'kaihowl/vim-trailing-whitespace', { 'branch': 'reset-on-ft' }
 
 Plug 'godlygeek/tabular'
 Plug 'justinmk/vim-sneak'
@@ -176,6 +177,11 @@ end
 "{{{ vim-indent-guides
 " Enable indent guides per default
 let g:indent_guides_enable_on_vim_startup = 1
+let g:indent_guides_exclude_filetypes = ['help', 'nerdtree', 'fzf']
+"}}}
+
+"{{{ vim-trailing-whitespace
+let g:extra_whitespace_ignored_filetypes = ['help', 'nerdtree', 'fzf']
 "}}}
 
 "{{{ helper functions


### PR DESCRIPTION
After nvim 0.8.0, indent guides and trailing whitespace was highlighted on the terminal window. Exclude the fzf filetype for both plugins.

Hotfix for #470

Unclear what changed in nvim 0.8.0 to start triggering these plugins. Not worth to investigate further, though: There was no use case for both plugins on the fzf terminal window anyhow.