### PR TITLE
fix(nvim): replace deprecated formatting_sync

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -896,7 +896,7 @@ smap <expr> <S-Tab> vsnip#jumpable(-1)  ? '<Plug>(vsnip-jump-prev)'      : '<S-T
 " Auto-format files when possible prior to saving
 augroup autoformat
   autocmd!
-  autocmd BufWritePre * lua vim.lsp.buf.formatting_sync(nil, 1000)
+  autocmd BufWritePre * lua vim.lsp.buf.format { timeout_ms = 1000 }
 augroup END
 " }}}
 


### PR DESCRIPTION
Fixes #475