### PR TITLE
fix(nvim): replace deprecated cmp-nvim-lsp function

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -773,8 +773,7 @@ local on_attach = function(client, bufnr)
 end
 
 -- The nvim-cmp almost supports LSP's capabilities so You should advertise it to LSP servers..
-local capabilities = vim.lsp.protocol.make_client_capabilities()
-capabilities = require('cmp_nvim_lsp').update_capabilities(capabilities)
+local capabilities = require('cmp_nvim_lsp').default_capabilities()
 
 -- Get compile_commands.json based on current working directory in case there are multiple available, e.g., conan workspaces with the workspace vs the single package build
 -- Supply an invalid dir to clangd in case that no compile_commands.json can be found in the current working dir. This restores the original behavior.


### PR DESCRIPTION
Fixes #479