### PR TITLE
feat(system): install automake, libtool, pkg-config

### DIFF
--- a/system/install.sh
+++ b/system/install.sh
@@ -3,8 +3,8 @@ set -e
 
 if [ "$(uname -s)" = "Darwin" ]; then
   source "$DOTS/common/brew.sh"
-  brew_install ncdu tree jq htop
+  brew_install ncdu tree jq htop automake libtool pkg-config
 elif [[ "$(lsb_release -i)" == *"Ubuntu"* ]]; then
   source "$DOTS/common/apt.sh"
-  apt_install ncdu tree jq htop
+  apt_install ncdu tree jq htop automake libtool pkg-config
 fi


### PR DESCRIPTION
This is for example assumed to be present on the host system for conan packages to compile. Let's install them by default.

Fixes #467