### PR TITLE
fix: improve shell handling / tests

### DIFF
--- a/nvim/tests/asyncrun-errorformat.test.vim
+++ b/nvim/tests/asyncrun-errorformat.test.vim
@@ -7,10 +7,11 @@ function Test()
   AsyncRun echo test
   call wait(10000, 'g:asyncrun_status == "success"')
   let qfitems = len(getqflist())
-  if qfitems != 3
+  if qfitems < 3
     echoerr 'Missing the command output'
-    echoerr 'Instead of header, footer, and a single line of command output'
+    echoerr 'Instead of header, footer, and at least a single line of command output'
     echoerr 'we received ' . qfitems . ' item(s)'
+    echoerr 'qflist: ' . join(getqflist())
     echoerr 'Command output omitted, likely wrong errorformat'
     mess
     cquit!

--- a/script/ci.sh
+++ b/script/ci.sh
@@ -3,13 +3,17 @@
 set -e
 set -x
 
+function identity() {
+  "$@"
+}
+
 if [[ $(uname) == *Darwin* ]]; then
   word_begin="[[:<:]]"
   word_end="[[:>:]]"
   # Use line buffering
   less_buffering="-l"
   # Do not use stdbuf (not available by default, not needed so far.)
-  stdbuf=()
+  stdbuf=(identity)
 else
   word_begin="\b"
   word_end="\b"

--- a/zsh/install.sh
+++ b/zsh/install.sh
@@ -15,7 +15,7 @@ elif [[ "$(lsb_release -i)" == *"Ubuntu"* ]]; then
 fi
 
 if [ -d "$checkout_path" ]; then
-  if [[ "${ZSH}" == "" ]]; then
+  if [[ -z "${ZSH:-}" ]]; then
     # Older zsh templates did not export ZSH var
     export ZSH=$checkout_path
   fi


### PR DESCRIPTION
This submits three small fixes found during running in a bash "strict"
mode for all spawned shells. Due to advice from
https://wiki.bash-hackers.org/scripting/obsolete, I am not sure if
there is much value in setting errexit, etc. on install scripts. It is
already set in test scripts, where I believe it is crucial.

- make asyncrun-errorformat.test.vim less sensitive
- an empty array (stdbuf in ci.sh) is considered an unbound variable
- fix an unbound variable in zsh/install.sh

Fixes https://github.com/kaihowl/dotfiles/issues/493