### PR TITLE
fix: shellcheck findings

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -150,7 +150,6 @@ then
     success "mac settings configured"
   else
     fail "error setting mac-specific settings"
-    exit 1
   fi
 fi
 

--- a/script/check_for_upgrade.sh
+++ b/script/check_for_upgrade.sh
@@ -40,7 +40,7 @@ then
   fi
 
   epoch_diff=$(($(_current_epoch) - LAST_EPOCH))
-  if [ $epoch_diff -ge $epoch_target ]
+  if [ $epoch_diff -ge "$epoch_target" ]
   then
     _upgrade_dots && _update_dots_update
   fi

--- a/zsh/window.zsh
+++ b/zsh/window.zsh
@@ -25,6 +25,7 @@ function get_host_from_ssh_config() {
 }
 
 function title() {
+  # shellcheck disable=SC2317
   case $TERM in
   screen|screen-256color|tmux|tmux-256color)
     precmd () {


### PR DESCRIPTION
Shellcheck 0.9.0 finds one unquoted comparison and multiple false positives in control flow analysis.

Fixes #510