### PR TITLE
feat(nvim): fzf-lua git branch allow switching submodule branches

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -304,6 +304,7 @@ require('fzf-lua').setup{
   git = {
     branches = {
       cmd = "git branch --color --sort=-committerdate",
+      cwd = "%:h:p"
     }
   }
 }


### PR DESCRIPTION
Align fzf-lua git branch behavior with fugitive: When a file from a submodule is the current file, use this files git dir instead of the git dir detected from the cwd.

Finishes #517