### PR TITLE
fix(nvim): freeze vim-trailing-whitespace at last working commit

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -134,7 +134,8 @@ Plug 'tpope/vim-abolish'
 Plug 'christoomey/vim-tmux-navigator'
 
 Plug 'nathanaelkane/vim-indent-guides'
-Plug 'bronson/vim-trailing-whitespace'
+" TODO(hoewelmk) #531 workaround
+Plug 'bronson/vim-trailing-whitespace', { 'tag': '9071740' }
 
 Plug 'godlygeek/tabular'
 Plug 'justinmk/vim-sneak'


### PR DESCRIPTION
Workaround for #531