### PR TITLE
fix(system): restore clean install run on Catalina

### DIFF
--- a/common/utilities.sh
+++ b/common/utilities.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+function version_less_than() {
+  actual_version=$1
+  expected_min_version=$2
+
+  ! [[ "$(sort -V <(printf "%s\n%s" "$actual_version" "$expected_min_version") | head -n 1)" == "$expected_min_version" ]]
+  return $?
+}
+
+function darwin_version() {
+  sw_vers -productVersion
+}

--- a/fzf/install.sh
+++ b/fzf/install.sh
@@ -10,7 +10,12 @@ fi
 
 if [ "$(uname)" == "Darwin" ]; then
   source "$DOTS/common/brew.sh"
-  brew_install curl wget
+  if ! which curl > /dev/null; then
+    brew_install curl
+  fi
+  if ! which wget > /dev/null; then
+    brew_install wget
+  fi
 elif [[ "$(lsb_release -i)" == *"Ubuntu"* ]]; then
   source "$DOTS/common/apt.sh"
   apt_install wget curl git

--- a/system/install.sh
+++ b/system/install.sh
@@ -3,7 +3,11 @@ set -e
 
 if [ "$(uname -s)" = "Darwin" ]; then
   source "$DOTS/common/brew.sh"
-  brew_install ncdu tree jq htop automake libtool pkg-config lnav
+  brew_install tree jq htop automake libtool pkg-config lnav
+  source "$DOTS/common/utilities.sh"
+  if ! version_less_than "$(darwin_version)" 11.0.0 ; then
+    brew_install ncdu
+  fi
 elif [[ "$(lsb_release -i)" == *"Ubuntu"* ]]; then
   source "$DOTS/common/apt.sh"
   apt_install ncdu tree jq htop automake libtool pkg-config lnav

--- a/system/test.sh
+++ b/system/test.sh
@@ -1,8 +1,11 @@
 #!/bin/zsh -i
 set -ex
 
-echo "Check if ncdu is available"
-which ncdu
+source "$DOTS/common/utilities.sh"
+if [ "$(uname)" != "Darwin" ] || ! version_less_than "$(darwin_version)" 11.0.0 ; then
+  echo "Check if ncdu is available"
+  which ncdu
+fi
 
 echo "Check if tree is available"
 which tree


### PR DESCRIPTION
- only install ncdu/wget on macOS 11 and later
  - zig as a dependency of ncdu is no longer available pre-Big Sur
- only install wget/curl if not yet there