### PR TITLE
fix(nvim): pin last working version of editorconfig

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -155,7 +155,8 @@ Plug 'kaiuri/nvim-juliana'
 Plug 'tommcdo/vim-fubitive' " Bitbucket
 Plug 'tpope/vim-rhubarb' " Github
 
-Plug 'editorconfig/editorconfig-vim'
+" TODO(kaihowl) #538 workaround
+Plug 'editorconfig/editorconfig-vim', { 'tag': '1d54632' }
 
 Plug 'tomtom/tcomment_vim'
 

--- a/nvim/tests/editorconfig.test.vim
+++ b/nvim/tests/editorconfig.test.vim
@@ -1,7 +1,4 @@
 function Test()
-  " TODO(kaihowl) Disabled due to #538
-  quit!
-
   noswap edit! test-editorconfig/somefile.txt
   if &textwidth == 111
   quit!


### PR DESCRIPTION
Also revert "test(nvim): disable failing test (#539)"

This reverts commit dc39447fb24897595246541e5707410b3e618d6d.

Part of #538