### PR TITLE
fix(nvim): switch back to upstream vim-trailing-whitespace plugin

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -134,8 +134,7 @@ Plug 'tpope/vim-abolish'
 Plug 'christoomey/vim-tmux-navigator'
 
 Plug 'nathanaelkane/vim-indent-guides'
-" TODO(hoewelmk) #531 workaround
-Plug 'bronson/vim-trailing-whitespace', { 'tag': '9071740' }
+Plug 'bronson/vim-trailing-whitespace'
 
 Plug 'godlygeek/tabular'
 Plug 'justinmk/vim-sneak'


### PR DESCRIPTION
The upstream fault from #531 is fixed.

Fixes #531.