### PR TITLE
chore(nvim): update to upstream editorconfig

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -154,8 +154,7 @@ Plug 'kaiuri/nvim-juliana'
 Plug 'tommcdo/vim-fubitive' " Bitbucket
 Plug 'tpope/vim-rhubarb' " Github
 
-" TODO(kaihowl) #538 workaround
-Plug 'editorconfig/editorconfig-vim', { 'tag': '1d54632' }
+Plug 'editorconfig/editorconfig-vim'
 
 Plug 'tomtom/tcomment_vim'
 


### PR DESCRIPTION
No workaround for #538 needed anymore as upstream was fixed.

Fixes #538