### PR TITLE
fix(nvim): make nvim segfault dormant again

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -583,6 +583,10 @@ augroup commit
 augroup END
 
 fun! s:commit_type()
+  " Redraw added to make neovim/neovim#14565 a dormant fault
+  " Otherwise, opening the commit message buffer and entering insert mode in
+  " quick succession will lead to a segfault.
+  redraw
   call complete(1, ['fix: ', 'feat: ', 'refactor: ', 'docs: ', 'test: ', 'ci: ', 'chore: ', 'perf: '])
   nunmap <buffer> i
   return ''


### PR DESCRIPTION
Fixes #546 with a work around.

By explicitly calling `redraw`, we make neovim/neovim#14565 dormant. The failure is triggered by requiring a redraw before the completion menu can be made visible. At least this is my understanding.

Work around the issue by forcing the redraw ourselves as part of the conventional commit completion code, which enables the original fault.