### PR TITLE
feat(script): user preset git user values when available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
           cd .dotfiles/
           git config --global user.email "git-perf@example.com"
           git config --global user.name "git-perf"
+          git config --list --show-origin
       - name: Install and test
         env:
           VERSION_RUNNER_OS: ${{ matrix.os }}
@@ -62,6 +63,7 @@ jobs:
           # Make `infocmp` for nvim healthcheck succeed
           export TERM=dumb
           cd .dotfiles/
+          git config --list --show-origin
           ./script/ci.sh
       - name: Rename versions report
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,9 +53,8 @@ jobs:
           VERSION_RUNNER_OS: ${{ matrix.os }}
         shell: bash
         run: |
-          export HOME=$(pwd)
           env
-          export XDG_CONFIG_HOME=$(pwd)/.config
+          export XDG_CONFIG_HOME=~/.config
           # Don't care about outdated, broken linkages on CI.
           # Otherwise, this might update node or php.
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -40,16 +40,18 @@ setup_gitconfig () {
       git_credential='osxkeychain'
     fi
 
+    preset_user=$(git config --global --get user.name || true)
     user ' - What is your github author name?'
-    if [[ "$CI" == "true" ]]; then
-       git_authorname='my_ci_user'
+    if [[ -n "${preset_user}" ]]; then
+       git_authorname=$preset_user
     else
       read -re git_authorname
     fi
 
+    preset_email=$(git config --global --get user.email || true)
     user ' - What is your github author email?'
-    if [[ "$CI" == "true" ]]; then
-      git_authoremail='ci@example.com'
+    if [[ -n "${preset_email}" ]]; then
+      git_authoremail=$preset_email
     else
       read -re git_authoremail
     fi


### PR DESCRIPTION
In codespaces, this information is already set and should be used (and duplicated into the git credentials file. Without duplicating, we run the risk that the original source of the preset values is altered. This is a change in behavior.

This change allows dotfiles to be used in the setup of a codespace.

Part of #550.