### PR TITLE
refactor: trigger install from bootstrap step

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,8 @@ Run this:
 ```sh
 git clone https://github.com/kaihowl/dotfiles.git ~/.dotfiles
 cd ~/.dotfiles
-# Actual sourcing/linking of dotfiles
+# Actual sourcing/linking of dotfiles and installation
 script/bootstrap
-# Optionally, install packages
-script/install
 # Optionally, run the tests
 script/test
 ```

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -156,5 +156,7 @@ then
   fi
 fi
 
+"${DOTFILES_ROOT}/script/install"
+
 echo ''
 echo '  All installed!'

--- a/script/ci.sh
+++ b/script/ci.sh
@@ -35,10 +35,8 @@ function decorate() {
 source common/perf.sh
 CI_START=$(date +%s)
 
-"${stdbuf[@]}" ./script/bootstrap > >(decorate) 2>&1
-
 INSTALL_START=$(date +%s)
-"${stdbuf[@]}" ./script/install > >(decorate) 2>&1
+"${stdbuf[@]}" ./script/bootstrap > >(decorate) 2>&1
 INSTALL_END=$(date +%s)
 INSTALL_DURATION=$((INSTALL_END - INSTALL_START))
 add_measurement install $INSTALL_DURATION

--- a/script/upgrade.sh
+++ b/script/upgrade.sh
@@ -21,8 +21,6 @@ then
   sudo /usr/bin/true
   printf '\033[0;34m%s\033[0m\n' "Running bootstrap..."
   ./script/bootstrap
-  printf '\033[0;34m%s\033[0m\n' 'Running install...'
-  ./script/install
 
   if ! git --no-pager diff --exit-code master..origin/master > /dev/null; then
     printf '\033[0;31m%s\033[0m\n' 'You have pending, local changes. Use dot-export or push them.'


### PR DESCRIPTION
To allow one-command install and therefore support in the Codespaces setup for dotfiles, we need to immediately call install after the setup step.

Part of #550