### PR TITLE
test(nvim): fix healthcheck tests

### DIFF
--- a/nvim/test.sh
+++ b/nvim/test.sh
@@ -1,5 +1,5 @@
 #!/bin/zsh -i
-set -ex
+set -euxo pipefail
 
 echo "Check if nvim is available"
 which nvim
@@ -21,7 +21,11 @@ fi
 echo "Check health for errors"
 health_file=$(mktemp)
 trap 'rm -rf $health_file' EXIT
-nvim --headless +checkhealth "+write $health_file" +qa
+nvim --headless +checkhealth "+write! $health_file" +qa!
+if [[ $(wc -l < "$health_file") -eq 0 ]]; then
+  echo "Health output is empty"
+  exit 1
+fi
 cat "$health_file"
 # Find all errors but exclude the optional node provider failure
 if grep -ie 'error' "$health_file" | grep -vie 'node -v'; then


### PR DESCRIPTION
Without pipefail, the error from the first grep command checking for "error" in the health file is not propagated.

More critically, the healthcheck file is never written as vim refuses to overwrite the created but empty temporary file.

Fixes #571

- [ ]  Double check output in jobs