### PR TITLE
fix(nvim): skip _only_ big buffers for completion

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -929,12 +929,13 @@ cmp.setup {
     { name = 'buffer',
       option = {
         get_bufnrs = function()
-          local buf = vim.api.nvim_get_current_buf()
-          local byte_size = vim.api.nvim_buf_get_offset(buf, vim.api.nvim_buf_line_count(buf))
-          if byte_size > 1024 * 1024 then -- 1 Megabyte max
-            return {}
+          local is_small_buf = function(index, buf)
+            local byte_size = vim.api.nvim_buf_get_offset(buf, vim.api.nvim_buf_line_count(buf))
+            return byte_size <= 1024*1024 -- 1 Megabyte max
           end
-          return { buf }
+
+          local all_bufs = vim.api.nvim_list_bufs()
+          return vim.fn.filter(all_bufs, is_small_buf)
         end
       }
     },


### PR DESCRIPTION
This is a fixup to 87825a3 which unfortunately wiped out indexing any other buffer than the current buffer. The current buffer was correctly skipped if too big.

This change restores indexing of other buffers (but still checks the maximum size).

Fixes #574