### PR TITLE
chore(nvim): upgrade to nvim 0.9.0

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,2 @@
+- remove editorconfig support
+- read rest of release notes

--- a/TODO
+++ b/TODO
@@ -1,2 +1,1 @@
-- remove editorconfig support
 - read rest of release notes

--- a/TODO
+++ b/TODO
@@ -1,1 +1,0 @@
-- read rest of release notes

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -69,8 +69,6 @@ set colorcolumn=81
 set list
 set listchars=eol:$,tab:>-,trail:~,extends:>,precedes:<
 
-set pastetoggle=<leader>p
-
 " Allow to delete old characters in insert mode
 " Also needed that latex-suite will be able to delete placeholders
 set backspace=2

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -156,8 +156,6 @@ Plug 'kaiuri/nvim-juliana'
 Plug 'tommcdo/vim-fubitive' " Bitbucket
 Plug 'tpope/vim-rhubarb' " Github
 
-Plug 'editorconfig/editorconfig-vim'
-
 Plug 'tomtom/tcomment_vim'
 
 Plug 'skywind3000/asynctasks.vim'

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -591,6 +591,8 @@ endfun
 "}}}
 
 "{{{ diffopt
+" Generally enable the second stage diff added in nvim 0.9
+set diffopt+=linematch:60
 " https://github.com/tommcdo/vimfiles/blob/master/config/diffopt.vim
 " Provide a function to toggle iwhite (ignore whitespace)
 function! s:toggle_iwhite(opt)

--- a/nvim/install.sh
+++ b/nvim/install.sh
@@ -3,14 +3,14 @@ set -ex
 
 SCRIPT_DIR=$(unset CDPATH; cd "$(dirname "$0")" > /dev/null; pwd -P)
 
-version=0.8.3
+version=0.9.0
 
 if [ "$(uname -s)" = "Darwin" ]; then
   download_url="https://github.com/neovim/neovim/releases/download/v${version}/nvim-macos.tar.gz"
-  expect_hash="26326708f34ead29e770514c2fb307702102166339c8f31660f7259ce9032925"
+  expect_hash="ba571c320c9ba98f1f78a9656b0b1fd21aa5833a61054f377c15c09366b96aca"
 elif [[ "$(lsb_release -i)" == *"Ubuntu"* ]]; then
   download_url="https://github.com/neovim/neovim/releases/download/v${version}/nvim-linux64.tar.gz"
-  expect_hash="58ac03b345e8675e13322f8c7135906ce26a1ca7a87d041344d64b207be7bedf"
+  expect_hash="fa93f06bec111fea6f316f186b96e19ba289a2dca2d0731e23597398b7397c8f"
 fi
 
 file_name=nvim-${version}.tar.gz


### PR DESCRIPTION
Update to nvim 0.9.

Remove deprecated paste toggle and superfluous editorconfig plugin.

Enable newly added linematch second-stage diff.