### PR TITLE
test(nvim): do not rely on default commentstring

### DIFF
--- a/nvim/tests/t_comment.test.vim
+++ b/nvim/tests/t_comment.test.vim
@@ -1,4 +1,6 @@
 function Test()
+  " Do not rely on default |commentstring|
+  set filetype=cpp
   call feedkeys('ivoid main() {}', 'x')
   call feedkeys('0w', 'x')
   " Comment out the word main


### PR DESCRIPTION
With nvim 0.9, the default commentstring is empty and this test will fail instead.