### PR TITLE
fix: use launchpadcontent instead of launchpad

### DIFF
--- a/alacritty/install.sh
+++ b/alacritty/install.sh
@@ -9,7 +9,7 @@ if [ "$(uname)" == "Darwin" ]; then
 elif [[ "$(lsb_release -i)" == *"Ubuntu"* ]]; then
   sudo snap remove alacritty || true
   source "${SCRIPT_DIR}/../common/apt.sh"
-  apt_add_repo alacritty http://ppa.launchpad.net/aslatter/ppa/ubuntu ::codename:: 3a160895cc2ce253085d08a552b24df7d43b5377
+  apt_add_repo alacritty https://ppa.launchpadcontent.net/aslatter/ppa/ubuntu ::codename:: 3a160895cc2ce253085d08a552b24df7d43b5377
   apt_install alacritty
 fi
 


### PR DESCRIPTION
Only launchpadcontent offers https. Launchpad.net is maintained for compatibility reasons only.

Fixes #594