### PR TITLE
fix(alacritty): workaround for already installed cask

### DIFF
--- a/alacritty/install.sh
+++ b/alacritty/install.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR=$(unset CDPATH; cd "$(dirname "$0")" > /dev/null; pwd -P)
 
 if [ "$(uname)" == "Darwin" ]; then
   source "${SCRIPT_DIR}/../common/brew.sh"
-  brew_install alacritty
+  brew_install alacritty || true # work around for #605
 elif [[ "$(lsb_release -i)" == *"Ubuntu"* ]]; then
   sudo snap remove alacritty || true
   source "${SCRIPT_DIR}/../common/apt.sh"


### PR DESCRIPTION
Installing an already installed cask now became a hard error. Work around this until an upstream solution is found.

Part of #605