### PR TITLE
feat(script): wait for apt lists lock once

### DIFF
--- a/bin/waiting-apt-get
+++ b/bin/waiting-apt-get
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Inspiration: https://askubuntu.com/a/375031
+# Instead of using DPkg::Lock::Timeout, which only works for the dpkg front end lock (/var/lib/dpkg/lock-frontend). This will also handle the /var/lib/apt/lists/lock in case of an update.
+# Since we usually install software after an update of the index, we wait for both locks even if this is not strictly necessary.
+# As this was intended to wait for packagekitd to finish operation after start up, I am ignoring the TOCTOU issue of this approach.
+
+function wait_on_lock {
+  lock=$1
+  i=0
+  tput sc
+  while fuser "$lock" >/dev/null 2>&1 ; do
+      case $((i % 4)) in
+          0 ) j="-" ;;
+          1 ) j="\\" ;;
+          2 ) j="|" ;;
+          3 ) j="/" ;;
+      esac
+      tput rc
+      echo -en "\r[$j] Waiting for $lock..."
+      sleep 0.5
+      ((i=i+1))
+  done
+}
+
+wait_on_lock /var/lib/dpkg/lock
+wait_on_lock /var/lib/apt/lists/lock

--- a/common/apt.sh
+++ b/common/apt.sh
@@ -1,11 +1,24 @@
 #!/bin/bash
 set -e
 
+SCRIPT_DIR=$(unset CDPATH; cd "$(dirname "$0")" > /dev/null; pwd -P)
+
+function wait_for_apt {
+  sudo "$SCRIPT_DIR/../bin/waiting-apt-get"
+}
+
+function apt_update() {
+  wait_for_apt
+  sudo apt-get update
+}
+
 function apt_install() {
+  wait_for_apt
   sudo apt-get install --upgrade -y "$@"
 }
 
 function apt_remove() {
+  wait_for_apt
   sudo apt-get remove -y "$@"
 }
 
@@ -56,5 +69,6 @@ function apt_add_repo() {
   sudo gpg --homedir /tmp --batch --keyserver keyserver.ubuntu.com --no-default-keyring --keyring "$keyring" --receive-keys "$key_id"
   echo "deb [signed-by=$keyring] $uri $suite main" | sudo tee "$list_name"
   echo "deb-src [signed-by=$keyring] $uri $suite main" | sudo tee -a "$list_name"
+  wait_for_apt
   sudo apt-get update
 }

--- a/script/install
+++ b/script/install
@@ -1,12 +1,13 @@
 #!/bin/bash
 set -e
 
-source common/perf_stubs.sh
-
 cd "$(dirname "$0")"/..
 
+source common/perf_stubs.sh
+
 if [[ "$(uname)" == "Linux" && "$(lsb_release -i)" == *"Ubuntu"* ]]; then
-  sudo apt-get update
+  source common/apt.sh
+  apt_update
 fi
 
 if [[ "$(uname)" == *"Darwin"* ]] && [[ "$(xcode-select -p)" == *"CommandLineTools"* ]]; then


### PR DESCRIPTION
To ensure that after startup we can run successfully through script/install even if packagekitd temporarily holds the apt lists lock, we wait once for this lock.

Fixes #618