### PR TITLE
fix(git): do not apply a global ignoreRevsFile

### DIFF
--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -57,5 +57,3 @@
 	signingkey = ~/.ssh/id_rsa
 [commit]
 	gpgsign = true
-[blame]
-	ignoreRevsFile = .git-blame-ignore-revs


### PR DESCRIPTION
In repos without this file, git-blame will error out.