### PR TITLE
fix(alacritty): use both option keys on macOS as meta keys

### DIFF
--- a/alacritty/config--alacritty--alacritty.yml.symlink
+++ b/alacritty/config--alacritty--alacritty.yml.symlink
@@ -17,6 +17,8 @@ import:
   - ~/.color/alacritty.yml
 
 window:
+  # Use both option keys on macOS as the meta key
+  option_as_alt: Both
   # Background opacity
   #
   # Window opacity as a floating point number from `0.0` to `1.0`.


### PR DESCRIPTION
Necessary to use alt-a in fzf to select all matches.