### PR TITLE
fix(nvim): fzf git preview for different git dir than pwd

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -374,6 +374,14 @@ function parse_renamecopy_line(line)
   return prefix .. left .. suffix, prefix .. right .. suffix
 end
 
+function shortened_path(path, n_chars)
+  if #path <= n_chars then
+    return path
+  end
+
+  return require('fzf-lua.path').shorten(path, 1)
+end
+
 function buffer_commits(opts)
   local original_cursorpos = vim.api.nvim_win_get_cursor(0)
 
@@ -401,8 +409,7 @@ function buffer_commits(opts)
   local parsing_state = {filename = rel_path}
   local command = make_git_log_command(commit, abs_path, line_range)
   require'fzf-lua'.fzf_exec(command, {
-    -- requires test fix TODO(hoewelmk)
-    -- prompt = workspace_root .. '/',
+    prompt = shortened_path(workspace_root, 32) .. '/',
     fn_transform = function(line)
       -- Possible lines, see https://github.com/git/git/blob/07330a41d66a2c9589b585a3a24ecdcf19994f19/diff.c#L6091-L6119
       if vim.startswith(line, ' rename') or vim.startswith(line, ' copy') then

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -399,11 +399,12 @@ function buffer_commits(opts)
   -- for directory: {"HEAD", "/home/.../NERD_tree_1"}
   local comm_path = commit_and_path()
   local commit, abs_path = unpack(comm_path)
-  local rel_path = require'fzf-lua'.path.relative(abs_path or '', vim.loop.cwd())
+  local workspace_root = vim.fn.FugitiveWorkTree()
+  local rel_path = require'fzf-lua'.path.relative(abs_path or '', workspace_root)
   local parsing_state = {filename = rel_path}
   local command = make_git_log_command(commit, abs_path, line_range)
-  vim.notify("hoewelmk: " .. make_git_preview_command())
   require'fzf-lua'.fzf_exec(command, {
+    prompt = workspace_root .. '/',
     fn_transform = function(line)
       -- Possible lines, see https://github.com/git/git/blob/07330a41d66a2c9589b585a3a24ecdcf19994f19/diff.c#L6091-L6119
       if vim.startswith(line, ' rename') or vim.startswith(line, ' copy') then

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -269,7 +269,10 @@ function commit_and_path()
   local parsed = vim.fn.FugitiveParse(fugitive_path)
   if parsed[2] ~= '' then -- we parsed a fugitive:// url
     local commit, path = unpack(vim.fn.split(parsed[1], ':'))
-    local retval= {commit or "HEAD", path or vim.fn.FugitiveWorkTree()}
+
+    local worktree = vim.fn.FugitiveWorkTree()
+    local abs_path = path and worktree .. '/' .. path or worktree
+    local retval= {commit or "HEAD", abs_path}
     return retval
   else
     return {"HEAD", fugitive_path}

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -295,18 +295,15 @@ function make_git_log_command(commit, path, line_range)
   end
 
 
-  local comm = vim.fn.FugitiveShellCommand(opts)
-
-  vim.notify(comm)
-
-  return comm
+  return vim.fn.FugitiveShellCommand(opts)
 end
 
 function make_git_preview_command()
   local is_not_first_commit = vim.fn.FugitiveShellCommand({'rev-parse', '--quiet', '--verify', '--end-of-options', '{2}~1'})
   local show_diff = vim.fn.FugitiveShellCommand({'log', '--format=fuller', '-p', '--color', '--word-diff', '{2}~1..{2}', '--'}) .. ' {1}'
+  -- TODO(hoewelmk) fix up with out hack?
   local show_single_commit = vim.fn.FugitiveShellCommand({'show', '{2}', '--'}) .. ' {1}'
-  return "echo '" .. show_single_commit .. "'"
+  return "if " .. is_not_first_commit .. " > /dev/null; then " .. show_diff .. "; else " .. show_single_commit .. "; fi"
 end
 
 local sel_to_qf = function(selected, _opts)
@@ -404,17 +401,16 @@ function buffer_commits(opts)
   local parsing_state = {filename = rel_path}
   local command = make_git_log_command(commit, abs_path, line_range)
   require'fzf-lua'.fzf_exec(command, {
-    prompt = workspace_root .. '/',
+    -- requires test fix TODO(hoewelmk)
+    -- prompt = workspace_root .. '/',
     fn_transform = function(line)
       -- Possible lines, see https://github.com/git/git/blob/07330a41d66a2c9589b585a3a24ecdcf19994f19/diff.c#L6091-L6119
       if vim.startswith(line, ' rename') or vim.startswith(line, ' copy') then
         local from, to = parse_renamecopy_line(line)
-        local result = 'hoewelmk: parsed renamed/copy from ' .. from .. ' to ' .. to
         if parsing_state.filename == to then
           parsing_state.filename = from
-          result = result .. ' and set parsing_state to ' .. parsing_state.filename
         end
-        return result
+        return
       end
       if line == ''
          or vim.startswith(line, ' create')

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -272,8 +272,7 @@ function commit_and_path()
 
     local worktree = vim.fn.FugitiveWorkTree()
     local abs_path = path and worktree .. '/' .. path or worktree
-    local retval= {commit or "HEAD", abs_path}
-    return retval
+    return {commit or "HEAD", abs_path}
   else
     return {"HEAD", fugitive_path}
   end

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -294,16 +294,19 @@ function make_git_log_command(commit, path, line_range)
     table.insert(opts, path)
   end
 
-  vim.notify(vim.inspect(opts))
 
-  return vim.fn.FugitiveShellCommand(opts)
+  local comm = vim.fn.FugitiveShellCommand(opts)
+
+  vim.notify(comm)
+
+  return comm
 end
 
 function make_git_preview_command()
   local is_not_first_commit = vim.fn.FugitiveShellCommand({'rev-parse', '--quiet', '--verify', '--end-of-options', '{2}~1'})
-  local show_diff = vim.fn.FugitiveShellCommand({'log', '--format=fuller', '-p', '--color', '--word-diff', '{2}~1..{2}', '--', '{1}'})
-  local show_single_commit = vim.fn.FugitiveShellCommand({'show', '{2}', '--', '{1}'})
-  return "if " .. is_not_first_commit .. " > /dev/null; then " .. show_diff .. "; else " .. show_single_commit .. "; fi"
+  local show_diff = vim.fn.FugitiveShellCommand({'log', '--format=fuller', '-p', '--color', '--word-diff', '{2}~1..{2}', '--'}) .. ' {1}'
+  local show_single_commit = vim.fn.FugitiveShellCommand({'show', '{2}', '--'}) .. ' {1}'
+  return "echo '" .. show_single_commit .. "'"
 end
 
 local sel_to_qf = function(selected, _opts)
@@ -399,17 +402,20 @@ function buffer_commits(opts)
   local rel_path = require'fzf-lua'.path.relative(abs_path or '', vim.loop.cwd())
   local parsing_state = {filename = rel_path}
   local command = make_git_log_command(commit, abs_path, line_range)
+  vim.notify("hoewelmk: " .. make_git_preview_command())
   require'fzf-lua'.fzf_exec(command, {
     fn_transform = function(line)
       -- Possible lines, see https://github.com/git/git/blob/07330a41d66a2c9589b585a3a24ecdcf19994f19/diff.c#L6091-L6119
       if vim.startswith(line, ' rename') or vim.startswith(line, ' copy') then
         local from, to = parse_renamecopy_line(line)
+        local result = 'hoewelmk: parsed renamed/copy from ' .. from .. ' to ' .. to
         if parsing_state.filename == to then
           parsing_state.filename = from
+          result = result .. ' and set parsing_state to ' .. parsing_state.filename
         end
-        return
+        return result
       end
-      if line == '' 
+      if line == ''
          or vim.startswith(line, ' create')
          or vim.startswith(line, ' mode')
          or vim.startswith(line, ' rewrite') then

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -303,9 +303,8 @@ end
 
 function make_git_preview_command()
   local is_not_first_commit = vim.fn.FugitiveShellCommand({'rev-parse', '--quiet', '--verify', '--end-of-options', '{2}~1'})
-  local show_diff = vim.fn.FugitiveShellCommand({'log', '--format=fuller', '-p', '--color', '--word-diff', '{2}~1..{2}', '--'}) .. ' {1}'
-  -- TODO(hoewelmk) fix up with out hack?
-  local show_single_commit = vim.fn.FugitiveShellCommand({'show', '{2}', '--'}) .. ' {1}'
+  local show_diff = vim.fn.FugitiveShellCommand({'log', '--format=fuller', '-p', '--color', '--word-diff', '{2}~1..{2}'}) .. " -- {1}"
+  local show_single_commit = vim.fn.FugitiveShellCommand({'show', '{2}'}) .. " -- {1}"
   return "if " .. is_not_first_commit .. " > /dev/null; then " .. show_diff .. "; else " .. show_single_commit .. "; fi"
 end
 

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -299,6 +299,13 @@ function make_git_log_command(commit, path, line_range)
   return vim.fn.FugitiveShellCommand(opts)
 end
 
+function make_git_preview_command()
+  local is_not_first_commit = vim.fn.FugitiveShellCommand({'rev-parse', '--quiet', '--verify', '--end-of-options', '{2}~1'})
+  local show_diff = vim.fn.FugitiveShellCommand({'log', '--format=fuller', '-p', '--color', '--word-diff', '{2}~1..{2}', '--', '{1}'})
+  local show_single_commit = vim.fn.FugitiveShellCommand({'show', '{2}', '--', '{1}'})
+  return "if " .. is_not_first_commit .. " > /dev/null; then " .. show_diff .. "; else " .. show_single_commit .. "; fi"
+end
+
 local sel_to_qf = function(selected, _opts)
   local qf_list = {}
   for _, selection in ipairs(selected) do
@@ -417,7 +424,7 @@ function buffer_commits(opts)
     fzf_opts = {
       ['--delimiter'] = '"' .. separator .. '"',
     },
-    preview = "if git rev-parse --quiet --verify --end-of-options {2}~1 > /dev/null; then git log --format=fuller -p --color --word-diff {2}~1..{2} -- {1}; else git show {2} -- {1}; fi",
+    preview = make_git_preview_command(),
     actions={
       ['default'] = curry_with_original_cursorpos(git_edit_or_qf),
       ['ctrl-s'] = git_split,

--- a/nvim/tests/fzf-git.test.vim
+++ b/nvim/tests/fzf-git.test.vim
@@ -63,7 +63,7 @@ function WaitForTerminalContent(pattern)
 endfunction
 
 function WaitForFzfResults(num_results)
-  call WaitForTerminalContent('> .* < ' . a:num_results . '/')
+  call WaitForTerminalContent(' < ' . a:num_results . '/')
 endfunction
 
 function CdTestDir()
@@ -468,7 +468,7 @@ function Test_DifferentPwd()
   edit firstfile
 
   " Go to different testdir than where current "firstfile" is located in
-  cd "/"
+  call CdTestDir()
 
   " English language necessary to check for "fatal:" and "Author:" strings
   call setenv('LC_ALL', 'en_US.UTF8')
@@ -500,6 +500,16 @@ function Test()
     execute 'call ' . test_function
   endfor
 
-  " call CleanUpDirs()
+  call CleanUpDirs()
 
+  if len(v:errors) != 0
+    for error in v:errors
+      for line in split(error,"\n")
+        echoerr line
+      endfor
+    endfor
+    cquit!
+  endif
+
+  qall!
 endfunction

--- a/nvim/tests/fzf-git.test.vim
+++ b/nvim/tests/fzf-git.test.vim
@@ -457,6 +457,19 @@ function Test_CopiedFileFollow()
   call assert_match('firstfile$', bufname(), 'Wrong file name (copied-from)')
 endfunction
 
+function Check_DifferentPwd(id)
+  call WaitForFzfResults(1)
+
+  call WaitForScreenContent('Author:\|fatal:')
+
+  let broken_preview = search('fatal:', 'w')
+  call assert_equal(0, broken_preview, 'preview is broken')
+  let working_preview = search('Author:', 'w')
+  call assert_notequal(0, working_preview, 'did not find preview')
+
+  call nvim_input('i<cr>')
+endfunction
+
 function Test_DifferentPwd()
   call CdTestDir()
 
@@ -473,16 +486,15 @@ function Test_DifferentPwd()
   " English language necessary to check for "fatal:" and "Author:" strings
   call setenv('LC_ALL', 'en_US.UTF8')
 
-  call feedkeys(',gl', 'tx')
+  call timer_start(50, funcref('Check_DifferentPwd'))
+  call feedkeys(',gl', 'tx!')
 
-  call WaitForFzfResults(1)
+  " Explicitly use the HEAD version of the 'firstfile'
+  Gedit HEAD:%
 
-  call WaitForScreenContent('Author:\|fatal:')
+  call timer_start(50, funcref('Check_DifferentPwd'))
+  call feedkeys(',gl', 'tx!')
 
-  let broken_preview = search('fatal:', 'w')
-  call assert_equal(0, broken_preview, 'preview is broken')
-  let working_preview = search('Author:', 'w')
-  call assert_notequal(0, working_preview, 'did not find preview')
 endfunction
 
 function Test()

--- a/nvim/tests/fzf-git.test.vim
+++ b/nvim/tests/fzf-git.test.vim
@@ -468,7 +468,7 @@ function Test_DifferentPwd()
   edit firstfile
 
   " Go to different testdir than where current "firstfile" is located in
-  call CdTestDir()
+  cd "/"
 
   " English language necessary to check for "fatal:" and "Author:" strings
   call setenv('LC_ALL', 'en_US.UTF8')
@@ -500,16 +500,6 @@ function Test()
     execute 'call ' . test_function
   endfor
 
-  call CleanUpDirs()
+  " call CleanUpDirs()
 
-  if len(v:errors) != 0
-    for error in v:errors
-      for line in split(error,"\n")
-        echoerr line
-      endfor
-    endfor
-    cquit!
-  endif
-
-  qall!
 endfunction

--- a/nvim/tests/fzf-git.test.vim
+++ b/nvim/tests/fzf-git.test.vim
@@ -202,7 +202,7 @@ function CheckFileChangingName(id)
   let unrelated_commit_line = search('unrelated commit', 'w')
   call assert_equal(0, unrelated_commit_line, 'unrelated commit in fzf window')
 
-  call feedkeys("\<esc>")
+  call nvim_input('<cr>')
 endfunction
 
 function Test_FileChangingName()

--- a/nvim/tests/fzf-git.test.vim
+++ b/nvim/tests/fzf-git.test.vim
@@ -487,7 +487,7 @@ endfunction
 
 function Test()
   " Source https://vimways.org/2019/a-test-to-attest-to/
-  let tests = split(substitute(execute('function /^Test_DifferentPwd'),
+  let tests = split(substitute(execute('function /^Test_'),
                             \  'function \(\k*()\)',
                             \  '\1',
                             \  'g'))

--- a/nvim/tests/fzf-git.test.vim
+++ b/nvim/tests/fzf-git.test.vim
@@ -493,9 +493,12 @@ function Test()
                             \  'g'))
 
   for test_function in tests
+    " first to kill any open fzf windows
     %bwipe!
-
+    " second to actually kill remaining buffers
+    %bwipe!
     echom 'Testing ' . test_function
+
 
     execute 'call ' . test_function
   endfor


### PR DESCRIPTION
Fixes #643

Introduces a prompt showing "lua-fzf.Files"-like shortened path. Paths in the results as well as in the commands are always relative to the current git worktree.