### PR TITLE
feat(osx): automatically install rosetta

### DIFF
--- a/osx/install.sh
+++ b/osx/install.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  exit
+fi
+
+if [ "$(uname -m)" != "arm64" ]; then
+  exit
+fi
+
+if ! [[ -f /Library/Apple/usr/libexec/oah/libRosettaRuntime ]]; then
+  sudo softwareupdate --install-rosetta --agree-to-license
+fi


### PR DESCRIPTION
Install rosetta on macOS unconditionally. Assume that no Intel mac is used anymore.

This is needed to run shellcheck for example.

Fixes #660