### PR TITLE
feat(git): default key type is ed25119 now

### DIFF
--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -53,7 +53,5 @@
 	process = git-lfs filter-process
 [init]
 	defaultBranch = master
-[user]
-	signingkey = ~/.ssh/id_rsa
 [commit]
 	gpgsign = true

--- a/git/gitconfig_credentials.example
+++ b/git/gitconfig_credentials.example
@@ -1,5 +1,6 @@
 [user]
-        name = AUTHORNAME
+        name  = AUTHORNAME
         email = AUTHOREMAIL
+	signingkey  = ~/.ssh/id_ed25519
 [credential]
         helper = GIT_CREDENTIAL_HELPER

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -58,6 +58,11 @@ setup_gitconfig () {
 
     success 'gitconfig'
   fi
+  # Temporary work around: If gitconfig_credentials does not yet have the signingkey,
+  # add the old rsa default
+  if ! grep -q0 "signingkey" ~/.gitconfig_credentials; then
+    printf "[user]\n  signingkey = ~/.ssh/id_rsa" >> ~/.gitconfig_credentials
+  fi
 }
 
 link_files () {


### PR DESCRIPTION
Signing key is managed in machine-specific gitconfig_credentials file. For existing installation, the assumed default is id_rsa instead.

Fixes #662