### PR TITLE
fix(nvim): absolute file path for fzf git branch switch

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -490,7 +490,7 @@ require('fzf-lua').setup{
   git = {
     branches = {
       cmd = "git branch --color --sort=-committerdate",
-      cwd = "%:h:p"
+      cwd = "%:p:h"
     }
   },
   lsp = {


### PR DESCRIPTION
"p" must come first to make it an absolute path.