### PR TITLE
fix(zsh): delete superfluous key bindings

### DIFF
--- a/zsh/pattern-search.zsh
+++ b/zsh/pattern-search.zsh
@@ -1,2 +1,0 @@
-bindkey "^R" history-incremental-pattern-search-backward
-bindkey "^S" history-incremental-pattern-search-forward


### PR DESCRIPTION
Since the introduction of fzf, these key bindings are no longer relevant.