### PR TITLE
fix(script): allow overwriting of broken symlink

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -90,7 +90,7 @@ link_dotfiles () {
 
     mkdir -p "$(dirname "$dest")"
 
-    if [ -f "$dest" ] || [ -d "$dest" ]
+    if [ -f "$dest" ] || [ -d "$dest" ] || [ -h "$dest" ]
     then
 
       overwrite=false


### PR DESCRIPTION
Neither -f nor -e (or any other file check) recognizes a broken symlink as "existing", i.e., "the file name is occupied".

Fixes #674