### PR TITLE
feat(osx): start GnuCash always in German

### DIFF
--- a/osx/set-defaults.sh
+++ b/osx/set-defaults.sh
@@ -47,3 +47,5 @@ defaults write NSGlobalDomain WebKitDeveloperExtras -bool true
 # Set standby to 90 minutes when on battery power
 echo "Trying to change battery standbydelay to 90 mins"
 sudo pmset -b standbydelay 5400
+
+defaults write org.gnucash.Gnucash AppleLanguages '(de)'


### PR DESCRIPTION
Fixes #665