### PR TITLE
chore(clangd): update clangd to 17.0.3

### DIFF
--- a/clangd/install.sh
+++ b/clangd/install.sh
@@ -4,9 +4,9 @@ set -e
 SCRIPT_DIR=$(unset CDPATH; cd "$(dirname "$0")" > /dev/null; pwd -P)
 
 if [ "$(uname)" == "Darwin" ]; then
-  version=16.0.2
+  version=17.0.3
   download_url="https://github.com/clangd/clangd/releases/download/${version}/clangd-mac-${version}.zip"
-  expect_hash="0c2d19e200e5a2ce1f10f7a7ade8e9c0ee57be306022a8b9eb0c79d0c8af1cdd"
+  expect_hash="7c311297ad28dd516ebcc3f902652cb729bbe34840806d2d5b1bebed1a9bba17"
 
   file_name=clangd-mac-${version}.zip
 


### PR DESCRIPTION
- [x] Wait for full release https://github.com/clangd/clangd/releases

The release is still marked as pre-release. Upstream 17.0.3 has been released. I don't see a reason to not assume that this has been done in error. Let's start using 17.0.3 despite the "pre-release" state.