### PR TITLE
fix(system): remove lnav

### DIFF
--- a/system/install.sh
+++ b/system/install.sh
@@ -5,12 +5,12 @@ SCRIPT_DIR=$(unset CDPATH; cd "$(dirname "$0")" > /dev/null; pwd -P)
 
 if [ "$(uname -s)" = "Darwin" ]; then
   source "${SCRIPT_DIR}/../common/brew.sh"
-  brew_install tree jq htop automake libtool pkg-config lnav
+  brew_install tree jq htop automake libtool pkg-config
   source "${SCRIPT_DIR}/../common/utilities.sh"
   if ! version_less_than "$(darwin_version)" 11.0.0 ; then
     brew_install ncdu
   fi
 elif [[ "$(lsb_release -i)" == *"Ubuntu"* ]]; then
   source "${SCRIPT_DIR}/../common/apt.sh"
-  apt_install ncdu tree jq htop automake libtool pkg-config lnav
+  apt_install ncdu tree jq htop automake libtool pkg-config
 fi

--- a/system/test.sh
+++ b/system/test.sh
@@ -27,9 +27,3 @@ which htop
 
 echo "Check if htop is runnable"
 htop --version
-
-echo "Check if lnav is available"
-which lnav
-
-echo "Check if lnav is runnable"
-lnav -V


### PR DESCRIPTION
I am not using it. It builds dependencies from scratch in homebrew. Let's save some time.

Edit: the reason for building was the deprecation of mac-11. With #707, macos-11 was replaced by macos-12. This no longer makes this change strictly necessary.