### PR TITLE
fix(tmux): no manual terminfo for Sonoma

### DIFF
--- a/bin/termtest
+++ b/bin/termtest
@@ -1,0 +1,9 @@
+#!/bin/zsh
+
+echo -e "\e[1mbold\e[0m"
+echo -e "\e[3mitalic\e[0m"
+echo -e "\e[3m\e[1mbold italic\e[0m"
+echo -e "\e[4munderline\e[0m"
+echo -e "\e[9mstrikethrough\e[0m"
+echo -e "\e[31mHello World\e[0m"
+echo -e "\x1B[31mHello World\e[0m"

--- a/nvim/nvim-alias.zsh
+++ b/nvim/nvim-alias.zsh
@@ -1,1 +1,1 @@
-alias vim="TERM='' nvim"
+alias vim=nvim

--- a/tmux/install.sh
+++ b/tmux/install.sh
@@ -6,8 +6,7 @@ SCRIPT_DIR=$(unset CDPATH; cd "$(dirname "$0")" > /dev/null; pwd -P)
 if [ "$(uname)" == "Darwin" ]; then
   source "${SCRIPT_DIR}/../common/brew.sh"
   brew_install tmux
-  terminfofile="$(dirname "$0")/tmux-256color.terminfo"
-  tic -x "$terminfofile"
+  rm -rf ~/.terminfo/74/tmux-256color
 elif [[ "$(lsb_release -i)" == *"Ubuntu"* ]]; then
   source "${SCRIPT_DIR}/../common/apt.sh"
   apt_install tmux

--- a/tmux/tmux-256color.terminfo
+++ b/tmux/tmux-256color.terminfo
@@ -1,4 +1,0 @@
-tmux-256color|screen with 256 colors and italics,
-  ritm=\E[23m, rmso=\E[27m, sitm=\E[3m, smso=\E[7m, Ms@,
-  khome=\E[1~, kend=\E[4~,
-  use=xterm-256color, use=screen-256color,


### PR DESCRIPTION
With macOS sonoma, ncurses is updated to 6.0. This includes a tmux-256color config and our custom config is no longer needed.

Fixes: #700

- [x] Test that scrolling is fixed on work MBP