### PR TITLE
fix(nvim): drop unused pynvim provider

### DIFF
--- a/common/python.sh
+++ b/common/python.sh
@@ -13,21 +13,12 @@ function ensure_python_installed() {
   else
     # The apple xcode python is broken. Use brew's python version instead.
     source "${SCRIPT_DIR}/brew.sh"
-    # TODO(hoewelmk) workaround for #703
-    brew unlink python@3.12 || true
-    brew_install python@3.11
-    brew link python@3.11
+    brew_install python
   fi
 }
 
 function install_in_virtualenv() {
   ensure_python_installed
-  local python
-  if [[ "$(uname)" == "Linux" && "$(lsb_release -i)" == *"Ubuntu"* ]]; then
-    python=python
-  else
-    python=python3.11
-  fi
   # Using venv instead of virtualenv as homebrews virtualenv is completely
   # separate from its python. I.e., it is not installed as a site package.
   # Installing virtualenv globally defeats the purpose of having venvs in the
@@ -35,7 +26,7 @@ function install_in_virtualenv() {
   # Major difference, it does not seed wheel (needed by pynvim) into the
   # virtualenv. This is done manually including an upgrade of pip and
   # setuptools.
-  $python -m venv --upgrade ~/.virtualenvs/dotfiles-run
+  python3 -m venv ~/.virtualenvs/dotfiles-run
   # Must run independently as wheel is a non-declared dependency of some packages.
   ~/.virtualenvs/dotfiles-run/bin/python3 -m pip install --upgrade pip setuptools wheel
   ~/.virtualenvs/dotfiles-run/bin/python3 -m pip install --upgrade "$*"

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -2,10 +2,12 @@
 "{{{ misc options, sane defaults
 set modelines=1
 
+" Rely on 'native' Lua plugins.
 let g:loaded_python_provider = 0
-" let g:loaded_python3_provider = 1
-let g:virtualenv = '~/.virtualenvs/dotfiles-run/bin'
-let g:python3_host_prog = g:virtualenv.'/python3'
+let g:loaded_python3_provider = 0
+let g:loaded_ruby_provider = 0
+let g:loaded_node_provider = 0
+let g:loaded_perl_provider = 0
 
 set lazyredraw
 
@@ -1024,7 +1026,8 @@ configs.clangd.setup{root_dir=function(fname)
 
 configs.pylsp.setup{on_attach=on_attach, capabilities=capabilities}
 
-local pylsp_binary = vim.api.nvim_eval("expand(g:virtualenv)").."/pylsp"
+local virtualenv = '~/.virtualenvs/dotfiles-run/bin'
+local pylsp_binary = vim.api.nvim_eval("expand('".. virtualenv .. "/pylsp')")
 configs.pylsp.setup{cmd={pylsp_binary}, on_attach=on_attach, capabilities=capabilities}
 
 configs.efm.setup {

--- a/nvim/install.sh
+++ b/nvim/install.sh
@@ -27,9 +27,6 @@ tar -C ~/.nvim --extract -z -f "$(cache_path "${file_name}")" --strip-components
 script_dir=$(dirname "$0")
 . "${script_dir}/path.zsh"
 
-source "${SCRIPT_DIR}/../common/python.sh"
-install_in_virtualenv pynvim
-
 # update packages in Plug
 # install plug if not already installed
 plug_dir="${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.vim


### PR DESCRIPTION
Since the provider is unused, we don't need to fix the python3.12 incompatibility. Moreover, disable all external providers that are checked in the healthcheck.

Fixes: #703

Revert "fix(python): force python 3.11 (on macOS) (#704)"

This reverts commit 1f5118deeb52441ca9fd6feb8da7b3fe6784b465.