### PR TITLE
fix(zsh): grey (normal) / red (failed) prompt

### DIFF
--- a/zsh/p10k.zsh.symlink
+++ b/zsh/p10k.zsh.symlink
@@ -82,7 +82,7 @@
   typeset -g POWERLEVEL9K_PROMPT_ADD_NEWLINE=true
 
   # Magenta prompt symbol if the last command succeeded.
-  typeset -g POWERLEVEL9K_PROMPT_CHAR_OK_{VIINS,VICMD,VIVIS}_FOREGROUND=$magenta
+  typeset -g POWERLEVEL9K_PROMPT_CHAR_OK_{VIINS,VICMD,VIVIS}_FOREGROUND=$grey
   # Red prompt symbol if the last command failed.
   typeset -g POWERLEVEL9K_PROMPT_CHAR_ERROR_{VIINS,VICMD,VIVIS}_FOREGROUND=$red
   # Default prompt symbol.


### PR DESCRIPTION
Instead of magenta / red, which is almost indistinguishable.

Fixes #717