### PR TITLE
chore(cmake): update keyid

### DIFF
--- a/cmake/install.sh
+++ b/cmake/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 set -o pipefail
 
@@ -26,4 +26,3 @@ elif [[ "$(lsb_release -i)" == *"Ubuntu"* ]]; then
   apt_add_repo_with_keyfile kitware https://apt.kitware.com/ubuntu ::codename:: /usr/share/keyrings/kitware-archive-keyring.gpg
   apt_install cmake
 fi
-

--- a/cmake/install.sh
+++ b/cmake/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-set -e
+set -ex
+
+set -o pipefail
 
 SCRIPT_DIR=$(unset CDPATH; cd "$(dirname "$0")" > /dev/null; pwd -P)
 
@@ -8,10 +10,20 @@ if [ "$(uname)" == "Darwin" ]; then
   brew_install cmake
 elif [[ "$(lsb_release -i)" == *"Ubuntu"* ]]; then
   # install latest
-  # NOTE This explicitly forgoes using the kitware-archive-keyring for automatic key rotation.
-  # For uniformity with other packages, we will manually rotate the key.
   source "${SCRIPT_DIR}/../common/apt.sh"
-  apt_add_repo kitware https://apt.kitware.com/ubuntu ::codename:: f41e5eaee6993e4dec254b3542d5a192b819c5da
+  # bootstrap automatic key rotation
+  if ! [[ -f /usr/share/keyrings/kitware-archive-keyring.gpg ]]; then
+    apt_install wget
+    list_name=/etc/apt/sources.list.d/temp_kitware.list
+    trap 'sudo rm -rf $list_name' EXIT
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+    echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(lsb_release -c -s) main" | sudo tee "$list_name" >/dev/null
+    sudo apt-get update
+    sudo rm -rf /usr/share/keyrings/kitware-archive-keyring.gpg
+    apt_install kitware-archive-keyring
+    rm -rf "$list_name"
+  fi
+  apt_add_repo_with_keyfile kitware https://apt.kitware.com/ubuntu ::codename:: /usr/share/keyrings/kitware-archive-keyring.gpg
   apt_install cmake
 fi
 

--- a/cmake/install.sh
+++ b/cmake/install.sh
@@ -21,7 +21,7 @@ elif [[ "$(lsb_release -i)" == *"Ubuntu"* ]]; then
     sudo apt-get update
     sudo rm -rf /usr/share/keyrings/kitware-archive-keyring.gpg
     apt_install kitware-archive-keyring
-    rm -rf "$list_name"
+    sudo rm -rf "$list_name"
   fi
   apt_add_repo_with_keyfile kitware https://apt.kitware.com/ubuntu ::codename:: /usr/share/keyrings/kitware-archive-keyring.gpg
   apt_install cmake

--- a/common/apt.sh
+++ b/common/apt.sh
@@ -24,6 +24,47 @@ function apt_remove() {
   sudo apt-get remove -y "$@"
 }
 
+function apt_add_repo_with_keyfile() {
+  local name
+  name=$1
+  if [ -z "$name" ]; then
+    echo Missing name
+    exit 1
+  fi
+
+  local codename
+  codename=$(lsb_release -cs)
+
+  local uri
+  uri=${2//::codename::/$codename}
+  if [ -z "$uri" ]; then
+    echo Missing uri
+    exit 1
+  fi
+
+  local suite
+  suite=${3//::codename::/$codename}
+  if [ -z "$suite" ]; then
+    echo Missing suite
+    exit 1
+  fi
+
+  local key_file
+  key_file=$4
+  if [ -z "$key_file" ]; then
+    echo Missing key file
+    exit 1
+  fi
+
+  local list_name
+  list_name=/etc/apt/sources.list.d/$name.list
+
+  echo "deb [signed-by=$key_file] $uri $suite main" | sudo tee "$list_name"
+  echo "deb-src [signed-by=$key_file] $uri $suite main" | sudo tee -a "$list_name"
+  wait_for_apt
+  sudo apt-get update
+}
+
 # Replace add-apt-repository with safer variant:
 # Use pinned key and only use key for the package it was intended for.
 # apt-key and apt-add-repository are deprecated.
@@ -37,20 +78,20 @@ function apt_add_repo() {
     echo Missing name
     exit 1
   fi
-  local codename
-  codename=$(lsb_release -cs)
-  local uri
-  uri=${2//::codename::/$codename}
+
+  uri=$2
   if [ -z "$uri" ]; then
     echo Missing uri
     exit 1
   fi
+
   local suite
-  suite=${3//::codename::/$codename}
+  suite=$3
   if [ -z "$suite" ]; then
     echo Missing suite
     exit 1
   fi
+
   local key_id
   key_id=$4
   if [ -z "$key_id" ]; then
@@ -63,14 +104,9 @@ function apt_add_repo() {
   local keyring
   keyring=$keyring_dir/$name
 
-  local list_name
-  list_name=/etc/apt/sources.list.d/$name.list
-
   apt_install gpg ca-certificates lsb-release
   sudo mkdir -p "$keyring_dir"
   sudo gpg --homedir /tmp --batch --keyserver keyserver.ubuntu.com --no-default-keyring --keyring "$keyring" --receive-keys "$key_id"
-  echo "deb [signed-by=$keyring] $uri $suite main" | sudo tee "$list_name"
-  echo "deb-src [signed-by=$keyring] $uri $suite main" | sudo tee -a "$list_name"
-  wait_for_apt
-  sudo apt-get update
+
+  apt_add_repo_with_keyfile "$name" "$uri" "$suite" "$keyring"
 }


### PR DESCRIPTION
As the signing key for the kitware repo is not published on the ubuntu
keyserver anymore, we reinstate the automatic key rotation support.

This breaks consistency with other packages.

The apt.sh function are restructured accordingly.

Fixes: #726
