### PR TITLE
fix(nvim): do not rely on cached resume data for fzf-lua

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -356,7 +356,7 @@ function git_set_qf(selected, opts)
   vim.fn.setqflist({}, " ", {
     nr = "$",
     items = converted,
-    title = opts.__resume_data.last_query,
+    title = require('fzf-lua').get_last_query()
   })
   vim.cmd("copen")
 end


### PR DESCRIPTION
Fixes #739