### PR TITLE
feat(nvim): do not sort fzf git log entries

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -455,6 +455,7 @@ function buffer_commits(opts)
     end,
     fzf_opts = {
       ['--delimiter'] = '"' .. separator .. '"',
+      ['--no-sort'] = "",
     },
     preview = make_git_preview_command(),
     actions={


### PR DESCRIPTION
Keep the order as present in git.

Fixes #749