### PR TITLE
feat: support python black as a formatter

### DIFF
--- a/pyls/install.sh
+++ b/pyls/install.sh
@@ -7,4 +7,4 @@ source "${SCRIPT_DIR}/../common/python.sh"
 
 # Install autopep8 to activate optional source formatting in pyls
 install_in_virtualenv "python-lsp-server[all]"
-install_in_virtualenv "pyls-black"
+install_in_virtualenv "python-lsp-black"

--- a/pyls/install.sh
+++ b/pyls/install.sh
@@ -7,3 +7,4 @@ source "${SCRIPT_DIR}/../common/python.sh"
 
 # Install autopep8 to activate optional source formatting in pyls
 install_in_virtualenv "python-lsp-server[all]"
+install_in_virtualenv "pyls-black"


### PR DESCRIPTION
Enable black as the default formatter. This plugin does not allow configuring a different formatter on a project by project basis. As black is a wildly used formatter, this is acceptable to me.