### PR TITLE
fix(nvim): fix test with changed inline prompt

### DIFF
--- a/nvim/tests/fzf-git.test.vim
+++ b/nvim/tests/fzf-git.test.vim
@@ -63,7 +63,7 @@ function WaitForTerminalContent(pattern)
 endfunction
 
 function WaitForFzfResults(num_results)
-  call WaitForTerminalContent(' < ' . a:num_results . '/')
+  call WaitForTerminalContent(' ' . a:num_results . '/\d\+ (\d\+)')
 endfunction
 
 function CdTestDir()
@@ -666,7 +666,7 @@ function Test_InGitHubFiles()
 endfunction
 
 function Check_NoSortStep2(id)
-  call WaitForScreenContent('commit.*<.*/')  " 'commit' entered on prompt
+  call WaitForScreenContent('commit.*/')  " 'commit' entered on prompt
 
   let correct_order = search('commit title.*\n.*commit title with a longer word', 'w')
   call assert_notequal(0, correct_order, 'order of commits incorrect')


### PR DESCRIPTION
With https://github.com/ibhagwan/fzf-lua/commit/f1c65edce7889181b083f85a98db2e0f69cab926, the prompt change to no longer contain the `>` character as a prefix.