### PR TITLE
fix(nimv): remove unused dap plugin

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -114,7 +114,6 @@ Plug 'vim-scripts/linediff.vim'
 Plug 'neovim/nvim-lspconfig'
 Plug 'simrat39/rust-tools.nvim'
 Plug 'nvim-lua/plenary.nvim'
-Plug 'mfussenegger/nvim-dap'
 
 Plug 'udalov/kotlin-vim'
 "


### PR DESCRIPTION
removal needed as the healthcheck checks for lldb-vscode install, which we currently don't have.