### PR TITLE
test(nvim): disable lsp-completion-rust.test.vim

### DIFF
--- a/nvim/tests/lsp-completion-rust.test.vim
+++ b/nvim/tests/lsp-completion-rust.test.vim
@@ -1,5 +1,7 @@
 source lsp-completion.template.vim
 
 function Test()
-  call FullTest('test-rustanalyzer/src/main.rs', 'writ', 'writeln')
+  " Disabled #779
+  " call FullTest('test-rustanalyzer/src/main.rs', 'writ', 'writeln')
+  qall!
 endfunction


### PR DESCRIPTION
Due to #779

Topic: disable-test