### PR TITLE
feat(git): set semicolon as comment char

### DIFF
--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -23,6 +23,7 @@
         ui = true
 [core]
         excludesfile = ~/.gitignore
+        commentChar = ";"
 [apply]
         whitespace = warn
 [mergetool]


### PR DESCRIPTION
Many github templates use # to start an h1. title. This conflicts with
the git comment marker. Deconflict by using a semicolon instead.

topic:git-comment-marker