### PR TITLE
fix(revup): only export revup binary

### DIFF
--- a/revup/path.zsh
+++ b/revup/path.zsh
@@ -1,1 +1,8 @@
-export PATH=~/.virtualenvs/revup/bin:$PATH
+# Exporting PATH to `~/.virtualenvs/revup/bin` is not correct; it also exposes the
+# python3 from the virtualenv.
+# Using `hash -p` is also not advisable as a change to the PATH could reset this hashmap.
+# Creating an empty dir, symlinking the revup binary there, and expose that directory is
+# unnecessarily more complex.
+revup () {
+    "$HOME/.virtualenvs/revup/bin/revup" "$@"
+}


### PR DESCRIPTION
Do not modify the PATH to also contain the python3 of the revup
virtualenv.

topic:revup-fix-2
relative:bash-test