### PR TITLE
refactor: zsh shebang based on env

### DIFF
--- a/alacritty/test.sh
+++ b/alacritty/test.sh
@@ -1,4 +1,5 @@
-#!/bin/zsh -i
+#!/usr/bin/env zsh
+
 set -e
 
 echo "Check if alacritty is installed"

--- a/ccache/test.sh
+++ b/ccache/test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh -i
+#!/usr/bin/env zsh
 set -e
 
 echo "Check if ccache is available"

--- a/clangd/test.sh
+++ b/clangd/test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh -i
+#!/usr/bin/env zsh
 set -e
 
 echo "Check if clangd is available"

--- a/cmake/test.sh
+++ b/cmake/test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh -i
+#!/usr/bin/env zsh
 set -e
 
 echo "Check if cmake is available"

--- a/colors/test.sh
+++ b/colors/test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh -i
+#!/usr/bin/env zsh
 
 set -e
 

--- a/ctags/test.sh
+++ b/ctags/test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh -i
+#!/usr/bin/env zsh
 set -e
 
 echo "Check if (universal-)ctags is available"

--- a/efm/test.sh
+++ b/efm/test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh -i
+#!/usr/bin/env zsh
 set -e
 
 echo "Check if efm-langserver is on path"

--- a/fzf/test.sh
+++ b/fzf/test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh -i
+#!/usr/bin/env zsh
 set -e
 
 echo "Checking whether fzf is on path"

--- a/git/test.sh
+++ b/git/test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh -i
+#!/usr/bin/env zsh
 set -e
 
 echo "Check if git is installed"

--- a/ninja/test.sh
+++ b/ninja/test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh -i
+#!/usr/bin/env zsh
 set -e
 
 echo "Check if ninja is available"

--- a/nvim/test.sh
+++ b/nvim/test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh -i
+#!/usr/bin/env zsh
 set -euo pipefail
 
 echo "Check if nvim is available"

--- a/revup/test.sh
+++ b/revup/test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 set -e
 
 echo "Check that 'revup' is on the path"

--- a/ripgrep/test.sh
+++ b/ripgrep/test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh -i
+#!/usr/bin/env zsh
 set -e
 
 echo "Check if ripgrep is available"

--- a/rust/test.sh
+++ b/rust/test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh -i
+#!/usr/bin/env zsh
 set -e
 
 echo "Check if rustc is on path"

--- a/shellcheck/test.sh
+++ b/shellcheck/test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh -i
+#!/usr/bin/env zsh
 set -e
 
 echo "Check if shellcheck is on path"

--- a/system/test.sh
+++ b/system/test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh -i
+#!/usr/bin/env zsh
 set -e
 
 source "$DOTS/common/utilities.sh"

--- a/vint/test.sh
+++ b/vint/test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh -i
+#!/usr/bin/env zsh
 set -e
 
 echo "Check if vim-vint is on path"

--- a/virtualenvwrapper/test.sh
+++ b/virtualenvwrapper/test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh -li
+#!/usr/bin/env zsh
 # Deliberately not set -e as the virtualenvwrapper functions inherit this.
 # I could not get the test to pass with it activated. If the actual expectations
 # of this test are not met, the test will still reliably fail, though.

--- a/zsh/test.sh
+++ b/zsh/test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 set -e
 
 echo "Test that start up and basic user input to shell work without errors"


### PR DESCRIPTION
With nix-installed (or other non-distro packet managers) zsh won't be
installed at the default `/bin/zsh` path. Prepare for this change by
using `/usr/bin/env zsh` to discover zsh from the PATH instead.

topic:zsh-path-test