### PR TITLE
fix(bin): use env-based zsh

### DIFF
--- a/bin/dot-export
+++ b/bin/dot-export
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 old_pwd=$(pwd)
 cd "$DOTS" || exit 1

--- a/bin/termtest
+++ b/bin/termtest
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 echo -e "\e[1mbold\e[0m"
 echo -e "\e[3mitalic\e[0m"

--- a/colors/bin/change-color
+++ b/colors/bin/change-color
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 set -e
 

--- a/script/check_for_upgrade.sh
+++ b/script/check_for_upgrade.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # Shamelessly copied from oh-my-zsh
 

--- a/script/upgrade.sh
+++ b/script/upgrade.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 # Shamelessly copied from oh my zsh
 
 printf '\033[0;34m%s\033[0m\n' "Upgrading Dotfiles"

--- a/zsh/zmv.zsh
+++ b/zsh/zmv.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 # Load and configure zsh move function for easier renaming of files with
 # patterns
 autoload zmv


### PR DESCRIPTION
With nix-controlled packages, zsh will no longer be present on
/bin/zsh. Account for that in scripts.

topic: zsh-env