### PR TITLE
ci: accept faster CI time

### DIFF
--- a/.gitperfconfig
+++ b/.gitperfconfig
@@ -1,0 +1,1 @@
+measurement = { ci = { epoch = "37c4b755" } }


### PR DESCRIPTION
macos latest got faster in CI measurement. Not investigated further.

topic: faster-ci