### PR TITLE
fix(nix): no-interactive shell needed for install

### DIFF
--- a/script/install
+++ b/script/install
@@ -40,15 +40,14 @@ if ! [ -f /nix/var/nix/profiles/default/bin/nix ]; then
   curl -L https://nixos.org/nix/install | sh -s -- --daemon
 fi
 
-# Instantiate the home-manager flake
-# TODO(kaihowl) remove impurity again
-bash -il -c 'nix run home-manager/release-24.05 -- --impure switch --flake .#myprofile'
-# This will make the nix-env invocations in the install files fail
-
 if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
   # shellcheck disable=SC1090,SC1091
   . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
 fi
+
+bash -c 'nix run home-manager/release-24.05 -- --impure switch --flake .#myprofile'
+# No explicit update for homebrew, there are enough update and cleanup
+# invocations automatically after a certain time has passed.
 
 # find the installers and run them iteratively
 # Run zsh install first


### PR DESCRIPTION
Correctly order the install of nix, the sourcing of the nix daemon env,
and the attempt to install the home-manager and its env.

With the previous interactive shell, calling upgrade.sh in an already
interactive shell leads to not executing the install and having
a nested shell.

topic: shell-nix