### PR TITLE
feat(git): configure signing key from key agent

### DIFF
--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -45,6 +45,8 @@
   prune = true
 [gpg]
 	format = ssh
+[gpg.ssh]
+  defaultKeyCommand = ssh-add -L
 [rerere]
 	enabled = true
 [filter "lfs"]

--- a/git/gitconfig_credentials.example
+++ b/git/gitconfig_credentials.example
@@ -1,6 +1,5 @@
 [user]
         name  = AUTHORNAME
         email = AUTHOREMAIL
-	signingkey  = ~/.ssh/id_ed25519
 [credential]
         helper = GIT_CREDENTIAL_HELPER

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -62,11 +62,6 @@ setup_gitconfig () {
 
     success 'gitconfig'
   fi
-  # Temporary work around: If gitconfig_credentials does not yet have the signingkey,
-  # add the old rsa default
-  if ! grep -q0 "signingkey" ~/.gitconfig_credentials; then
-    printf "[user]\n  signingkey = ~/.ssh/id_rsa" >> ~/.gitconfig_credentials
-  fi
 }
 
 link_files () {


### PR DESCRIPTION
This also allows to handle forward ssh keys that are not local to the
current machine.

topic:remote-git-ssh