### PR TITLE
fix(nvim): remove workaround for treesitter

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -1151,14 +1151,6 @@ nnoremap <M-l> :TmuxNavigateRight<cr>
 " nnoremap <silent> {Previous-Mapping} :TmuxNavigatePrevious<cr>
 "}}}
 
-"{{{ treesitter
-" # Workaround from https://github.com/neovim/neovim/issues/20456
-augroup TreeSitterVim
-  autocmd!
-  autocmd FileType vim lua vim.treesitter.start()
-augroup END
-"}}}
-
 "{{{ Oil
 lua <<EOF
 require('oil').setup({default_file_explorer = false})


### PR DESCRIPTION
This now leads to errors when displaying the config--nvim--init.vim
file. The heredocs with lua looks sufficiently correct in syntax
highlighting to not warrant the workaround.

topic: remove-treesitter-workaround