### PR TITLE
fix: add ci for minimal profile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,13 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-latest]
+        include:
+          - os: ubuntu-22.04
+            profile: full
+          - os: ubuntu-22.04
+            profile: minimal
+          - os: macos-latest
+            profile: full
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -59,6 +65,7 @@ jobs:
       - name: Install and test
         env:
           VERSION_RUNNER_OS: ${{ matrix.os }}
+          DOTFILES_PROFILE: ${{ matrix.profile }}
         shell: bash
         run: |
           env
@@ -75,13 +82,13 @@ jobs:
         if: always()
         run: |
           cd .dotfiles/
-          mv versions.txt versions-${{matrix.os}}.txt
+          mv versions.txt versions-${{matrix.os}}-${{matrix.profile}}.txt
       - name: Archive version report
         uses: actions/upload-artifact@v4
         if: always()
         with:
           include-hidden-files: true
-          name: versions-report-${{matrix.os}}
+          name: versions-report-${{matrix.os}}-${{matrix.profile}}
           path: .dotfiles/versions-*.txt
           if-no-files-found: error
   report:

--- a/common/perf.sh
+++ b/common/perf.sh
@@ -13,7 +13,14 @@ function add_measurement {
   name=$1
   value=$2
 
-  git perf add -m "$name" -k "os=${VERSION_RUNNER_OS}" "$value"
+  local os
+  if [[ $DOTFILES_PROFILE == minimal ]]; then
+    os=${VERSION_RUNNER_OS}-${DOTFILES_PROFILE}
+  else
+    os=${VERSION_RUNNER_OS}
+  fi
+
+  git perf add -m "$name" -k "os=$os" "$value"
 }
 
 function run_measurement {
@@ -26,8 +33,27 @@ function run_measurement {
     false
   fi
 
+  local os
+  if [[ $DOTFILES_PROFILE == minimal ]]; then
+    os=${VERSION_RUNNER_OS}-${DOTFILES_PROFILE}
+  else
+    os=${VERSION_RUNNER_OS}
+  fi
+
   name=$1
-  git perf measure -n 10 -m "$name" -k "os=${VERSION_RUNNER_OS}" -- "${@:2}"
+  git perf measure -n 10 -m "$name" -k "os=$os" -- "${@:2}"
+}
+
+function audit_measurements {
+  local os
+  if [[ $DOTFILES_PROFILE == minimal ]]; then
+    os=${VERSION_RUNNER_OS}-${DOTFILES_PROFILE}
+  else
+    os=${VERSION_RUNNER_OS}
+  fi
+
+  name=$1
+  git perf audit -n 40 -m "$name" -s "os=$os" --min-measurements 10
 }
 
 function publish_measurements {
@@ -40,6 +66,7 @@ function publish_measurements {
 # Make functions available in called bash scripts as well
 export -f add_measurement
 export -f run_measurement
+export -f audit_measurements
 export -f publish_measurements
 
 export DOTS_PERF_EXPORTED=true

--- a/common/perf_stubs.sh
+++ b/common/perf_stubs.sh
@@ -13,6 +13,10 @@ function run_measurement {
   /usr/bin/true
 }
 
+function audit_measurements {
+  /usr/bin/true
+}
+
 function publish_measurements {
   /usr/bin/true
 }
@@ -20,6 +24,7 @@ function publish_measurements {
 # Make functions available in called bash scripts as well
 export -f add_measurement
 export -f run_measurement
+export -f audit_measurements
 export -f publish_measurements
 
 export DOTS_PERF_EXPORTED=true

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -993,17 +993,20 @@ local capabilities = require('cmp_nvim_lsp').default_capabilities()
 
 -- Get compile_commands.json based on current working directory in case there are multiple available, e.g., conan workspaces with the workspace vs the single package build
 -- Supply an invalid dir to clangd in case that no compile_commands.json can be found in the current working dir. This restores the original behavior.
-configs.clangd.setup{root_dir=function(fname)
-    return root_pattern(vim.loop.cwd()) or util.path.dirname(fname)
-  end,
-  cmd={'clangd','--completion-style=detailed', '--background-index', '--compile-commands-dir='..(root_pattern(vim.loop.cwd()) or '')},
-  capabilities=capabilities,
-  on_attach=function(client, bufnr)
-    local opts = { noremap=true, silent=true }
-    vim.api.nvim_buf_set_keymap(bufnr, 'n', '<leader>gh', '<cmd>ClangdSwitchSourceHeader<CR>', opts)
-    on_attach(client, bufnr)
-  end
-}
+
+if (os.getenv('DOTS_PROFILE') or 'full') == 'full' then
+  configs.clangd.setup{root_dir=function(fname)
+      return root_pattern(vim.loop.cwd()) or util.path.dirname(fname)
+    end,
+    cmd={'clangd','--completion-style=detailed', '--background-index', '--compile-commands-dir='..(root_pattern(vim.loop.cwd()) or '')},
+    capabilities=capabilities,
+    on_attach=function(client, bufnr)
+      local opts = { noremap=true, silent=true }
+      vim.api.nvim_buf_set_keymap(bufnr, 'n', '<leader>gh', '<cmd>ClangdSwitchSourceHeader<CR>', opts)
+      on_attach(client, bufnr)
+    end
+  }
+end
 
 configs.pylsp.setup{on_attach=on_attach, capabilities=capabilities}
 
@@ -1024,19 +1027,22 @@ configs.efm.setup {
     filetypes = {'sh', 'zsh', 'vim'},
 }
 
-require('rust-tools').setup {
-  server = {
-    on_attach = on_attach,
-    capabilities = capabilities,
-    settings = {
-      ["rust-analyzer"] = {
-        checkOnSave = {
-          command = "clippy"
+if (os.getenv('DOTS_PROFILE') or 'full') == 'full' then
+  require('rust-tools').setup {
+    server = {
+      on_attach = on_attach,
+      capabilities = capabilities,
+      settings = {
+        ["rust-analyzer"] = {
+          checkOnSave = {
+            command = "clippy"
+          }
         }
       }
     }
   }
-}
+end
+
 -- Sourced from https://github.com/hrsh7th/nvim-cmp/wiki/Example-mappings
 local has_words_before = function()
   local line, col = unpack(vim.api.nvim_win_get_cursor(0))

--- a/script/ci.sh
+++ b/script/ci.sh
@@ -59,11 +59,11 @@ add_measurement ci $CI_DURATION
 publish_measurements
 
 set +e
-git perf audit -n 40 -m nvim -s "os=${VERSION_RUNNER_OS}" --min-measurements 10
+audit_measurements nvim
 nvim_exit=$?
-git perf audit -n 40 -m zsh -s "os=${VERSION_RUNNER_OS}" --min-measurements 10
+audit_measurements zsh
 zsh_exit=$?
-git perf audit -n 40 -m ci -s "os=${VERSION_RUNNER_OS}" --min-measurements 10
+audit_measurements ci
 ci_exit=$?
 set -e
 

--- a/script/install
+++ b/script/install
@@ -41,14 +41,18 @@ fi
 # Used by zsh installer and by colors installer.
 export PATH=~/.nix-profile/bin:$PATH
 
+source common/utilities.sh
+
 # find the installers and run them iteratively
 # Run zsh install first
 # If there are more dependencies between installers in the future,
 # this needs to be expanded.
 if [[ $DOTFILES_PROFILE == minimal ]]; then
-  installers="./nvim/install.sh ./colors/install.sh"
+  installers="./nvim/install.sh ./colors/install.sh ./zsh/install.sh"
+  sed_replace_in_file ~/.zprofile "# dots-profile" "export DOTS_PROFILE=minimal # dots-profile"
 else
   installers=$(find . -name nix -prune -o -name install.sh -print)
+  sed_replace_in_file ~/.zprofile "# dots-profile" "export DOTS_PROFILE=full # dots-profile"
 fi
 
 installers="./nix/install.sh $installers"

--- a/script/test
+++ b/script/test
@@ -13,13 +13,18 @@ fi
 
 # find all test scripts and run them
 tests=()
-while IFS= read -r -d '' test; do
-    tests+=("$test")
-done < <(find . -type f -name 'test.sh' -print0)
+if [[ $DOTFILES_PROFILE != minimal ]]; then
+  while IFS= read -r -d '' test; do
+      tests+=("$test")
+  done < <(find . -type f -name 'test.sh' -print0)
+else
+  # Tests for minimal configuration
+  tests=(colors/test.sh efm/test.sh fzf/test.sh git/test.sh nvim/test.sh revup/test.sh ripgrep/test.sh shellcheck/test.sh tmux/test.sh vint/test.sh virtualenvwrapper/test.sh zsh/test.sh)
+fi
 
 failed_tests=0
 for t in "${tests[@]}"; do
-  printf "Running \e[32m%s\e[0m" "${t}"
+  printf "Running \e[32m%s\e[0m\n" "${t}"
   if ! zsh -i -l "${t}"; then
       echo "ERROR: TEST ${t} FAILED"
       ((failed_tests+=1))


### PR DESCRIPTION
Make lsp config conditional for non-installed LSP servers. Otherwise,
the healthcheck of nvim fails.

Keep the old performance measurements. For the minimal profile, append
"-minimal" to the current os label. We do not support multiple labels
in the audit processing as of today.

topic: minimal-ci