### PR TITLE
feat(git): allow existing git config to coexist

### DIFF
--- a/git/gitconfig_credentials.example
+++ b/git/gitconfig_credentials.example
@@ -1,3 +1,0 @@
-[user]
-        name  = AUTHORNAME
-        email = AUTHOREMAIL

--- a/git/gitconfig_dotfiles.symlink
+++ b/git/gitconfig_dotfiles.symlink
@@ -1,5 +1,3 @@
-[include]
-        path = .gitconfig_credentials
 [credential]
 # This was introduced primarily to be the default way for revup to fetch the token.
         helper = "! gcm-client"

--- a/git/install.sh
+++ b/git/install.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR=$(unset CDPATH; cd "$(dirname "$0")" > /dev/null; pwd -P)
+
+source "$SCRIPT_DIR/../common/utilities.sh"
+
+touch ~/.gitconfig
+
+sed_replace_in_file ~/.gitconfig "# dotfiles" "[include] path=~/.gitconfig_dotfiles # dotfiles"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -52,7 +52,8 @@ setup_gitconfig () {
       read -re git_authoremail
     fi
 
-    sed -e "s/AUTHORNAME/$git_authorname/g" -e "s/AUTHOREMAIL/$git_authoremail/g" git/gitconfig_credentials.example > ~/.gitconfig_credentials
+    git config --global user.name "$git_authorname"
+    git config --global user.email "$git_authoremail"
 
     success 'gitconfig'
   fi

--- a/script/install
+++ b/script/install
@@ -47,7 +47,7 @@ fi
 # If there are more dependencies between installers in the future,
 # this needs to be expanded.
 if [[ $DOTFILES_PROFILE == minimal ]]; then
-  installers="./nvim/install.sh ./colors/install.sh ./zsh/install.sh ./ssh/install.sh"
+  installers="./git/install.sh ./nvim/install.sh ./colors/install.sh ./zsh/install.sh ./ssh/install.sh"
   sed_replace_in_file ~/.zprofile "# dots-profile" "export DOTFILES_PROFILE=minimal # dots-profile"
 else
   installers=$(find . -name nix -prune -o -name install.sh -print)


### PR DESCRIPTION
This does not migrate existing installations.

We want existing global git configs to continue to exist. We add our
additions to the git config at the bottom through an include instead.

topic: git-config-global