### PR TITLE
fix(macos): remove unnecessary full xcode install

### DIFF
--- a/script/install
+++ b/script/install
@@ -30,12 +30,6 @@ trap restore_selinux EXIT
 
 source common/perf_stubs.sh
 
-if [[ "$(uname)" == *"Darwin"* ]] && [[ "$(xcode-select -p)" == *"CommandLineTools"* ]]; then
-  # Full XCode is for example needed to compile pynvim's greenlet
-  printf "Running \e[32mFull XCode install needed\e[0m"
-  exit 1
-fi
-
 # TODO(kaihowl) hack
 # Already make all nix-installed binaries available
 # Used by zsh installer and by colors installer.


### PR DESCRIPTION
Not even homebrew seems to need that anymore. Let's remove the hard
requirement.

topic:no-xcode