### PR TITLE
fix(zsh): remove unnecessary sourcing of zsh in test

### DIFF
--- a/zsh/test.sh
+++ b/zsh/test.sh
@@ -14,8 +14,5 @@ echo "Test that start up and basic user input to shell work without errors"
 # sh:1: url-quote-magic: function definition file not found
 expect -c "strace 4" "$DOTS/zsh/userinput.test.expect"
 
-# shellcheck disable=SC1090
-source ~/.zshrc
-
 echo "Check that ctrl-z is registered"
 bindkey | grep -i '^"\^Z'


### PR DESCRIPTION
Unclear why added, not documented, leads to timeouts in CI. No actual
problems in implementation.

topic:remove-sourcing