### PR TITLE
chore(nvim): move available color schemes to nix

### DIFF
--- a/colors/bin/change-color
+++ b/colors/bin/change-color
@@ -8,7 +8,7 @@ mkdir -p ~/.color
 
 
 background=(dark)
-color=(edge)
+color=(gruvbox)
 
 if [[ -f ~/.color/current ]]; then
   IFS=":" read -r color background  < ~/.color/current

--- a/home.nix
+++ b/home.nix
@@ -112,6 +112,12 @@ in
         vim-gitgutter
         tagbar
         vim-addon-local-vimrc
+        # Color schemes
+        edge
+        gruvbox
+        tokyonight-nvim
+        onehalf
+        papercolor-theme
       ];
       withNodeJs = false;
       withPython3 = true;

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -121,11 +121,6 @@ Plug 'hrsh7th/vim-vsnip-integ'
 
 Plug 'kaihowl/vim-indent-sentence'
 
-Plug 'sainnhe/edge'
-Plug 'morhetz/gruvbox'
-Plug 'folke/tokyonight.nvim'
-Plug 'sonph/onehalf', { 'rtp': 'vim' }
-Plug 'NLKNguyen/papercolor-theme'
 Plug 'kaiuri/nvim-juliana'
 Plug '1612492/github.vim'
 


### PR DESCRIPTION
Make gruvbox the new default as edge modifies the non-writable plugin path on lazy load.

See https://github.com/sainnhe/edge/issues/79.