### PR TITLE
chore(nvim): move completion plugins to nix

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -118,6 +118,13 @@ in
         tokyonight-nvim
         onehalf
         papercolor-theme
+        # Completion plugins
+        nvim-cmp
+        cmp-nvim-lsp
+        cmp-buffer
+        cmp-vsnip
+        vim-vsnip
+        vim-vsnip-integ
       ];
       withNodeJs = false;
       withPython3 = true;

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -111,14 +111,6 @@ Plug 'stevearc/oil.nvim'
 
 Plug 'vim-scripts/linediff.vim'
 
-Plug 'hrsh7th/nvim-cmp'
-Plug 'hrsh7th/cmp-nvim-lsp'
-Plug 'hrsh7th/cmp-buffer'
-Plug 'hrsh7th/cmp-vsnip'
-
-Plug 'hrsh7th/vim-vsnip'
-Plug 'hrsh7th/vim-vsnip-integ'
-
 Plug 'kaihowl/vim-indent-sentence'
 
 Plug 'kaiuri/nvim-juliana'


### PR DESCRIPTION
topic: chorenvim-move-completion-plugins-to-nix
relative:chorenvim-move-available-color-schemes-to-nix
labels:draft