### PR TITLE
chore(nvim): remove unused fugitive handler / move rhubarb to nix

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -100,6 +100,7 @@ in
         kotlin-vim
         markdown-preview-nvim
         vim-fugitive
+        vim-rhubarb # github fugitive completion handler
         vim-unimpaired
         vim-repeat
         vim-surround

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -116,10 +116,6 @@ Plug 'kaihowl/vim-indent-sentence'
 Plug 'kaiuri/nvim-juliana'
 Plug '1612492/github.vim'
 
-" Fugitive browse handlers
-Plug 'tommcdo/vim-fubitive' " Bitbucket
-Plug 'tpope/vim-rhubarb' " Github
-
 Plug 'tomtom/tcomment_vim'
 
 Plug 'skywind3000/asynctasks.vim'


### PR DESCRIPTION
topic: chorenvim-remove-unused-fugitive-handler--move-rhubarb-to-nix
relative: chorenvim-move-completion-plugins-to-nix
labels: draft