### PR TITLE
chore(nvim): move asyncrun/asynctasks to nix

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -113,6 +113,8 @@ in
         vim-gitgutter
         tagbar
         vim-addon-local-vimrc
+        asyncrun-vim
+        asynctasks-vim
         # Color schemes
         edge
         gruvbox

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -118,9 +118,6 @@ Plug '1612492/github.vim'
 
 Plug 'tomtom/tcomment_vim'
 
-Plug 'skywind3000/asynctasks.vim'
-Plug 'skywind3000/asyncrun.vim'
-
 Plug 'ibhagwan/fzf-lua'
 
 Plug 'gaving/vim-textobj-argument'


### PR DESCRIPTION
topic: chorenvim-move-asyncrunasynctasks-to-nix
relative: chorenvim-remove-unused-fugitive-handler--move-rhubarb-to-nix
labels:draft