### PR TITLE
chore(nvim): move last two easily available plugins to nix

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -115,12 +115,16 @@ in
         vim-addon-local-vimrc
         asyncrun-vim
         asynctasks-vim
+        fzf-lua
+        tcomment_vim
+
         # Color schemes
         edge
         gruvbox
         tokyonight-nvim
         onehalf
         papercolor-theme
+
         # Completion plugins
         nvim-cmp
         cmp-nvim-lsp

--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -116,10 +116,6 @@ Plug 'kaihowl/vim-indent-sentence'
 Plug 'kaiuri/nvim-juliana'
 Plug '1612492/github.vim'
 
-Plug 'tomtom/tcomment_vim'
-
-Plug 'ibhagwan/fzf-lua'
-
 Plug 'gaving/vim-textobj-argument'
 
 " the plug#end automatically calls "filetype plugin indent on" and "syntax enable"


### PR DESCRIPTION
topic:chorenvim-move-last-two-easily-available-plugins-to-nix
relative: chorenvim-move-asyncrunasynctasks-to-nix
labels:draft