### PR TITLE
fix(colors): fix edge color scheme and nix behavior

### DIFF
--- a/colors/bin/change-color
+++ b/colors/bin/change-color
@@ -41,7 +41,6 @@ cat - > ~/.color/color.vim <<EOF
 let g:edge_enable_italic = 1
 let g:edge_disable_italic_comment = 0
 let g:edge_diagnostic_line_highlight = 1
-let g:edge_better_performance = 1
 colorscheme ${vim_colorscheme}
 set background=${background[-1]}
 EOF


### PR DESCRIPTION
Based on
https://github.com/sainnhe/edge/issues/79#issuecomment-2543904156,
disabling the edge_better_performance setting such that no files are
generated in the plugin folder. This would other break nix which has by
design an immutable store.

topic:fixcolors-fix-edge-color-scheme-and-nix-behavior