### PR TITLE
fix(zsh): reenable zsh test

### DIFF
--- a/zsh/test.sh
+++ b/zsh/test.sh
@@ -9,14 +9,17 @@ if [[ "${actual_path}" != /nix/store/* ]]; then
   exit 1
 fi
 
+echo "Test that zshrc can be sourced without errors"
+# shellcheck disable=SC1090
+zsh -c 'set -e; source ~/.zshrc'
+
 echo "Test that start up and basic user input to shell work without errors"
 # This was added after a faulty linter change led to printing the following on all key presses
 # sh:1: url-quote-magic: function definition file not found
-# TODO(kaihowl) reenable, times out on CI
-# expect -c "strace 4" "$DOTS/zsh/userinput.test.expect"
-
-# shellcheck disable=SC1090
-source ~/.zshrc
+# Could only get test passing on macOS.
+if [[ "$(uname)" == "Darwin" ]]; then
+  timeout 10s expect -c "strace 4" "$DOTS/zsh/userinput.test.expect"
+fi
 
 echo "Check that ctrl-z is registered"
 bindkey | grep -i '^"\^Z'

--- a/zsh/userinput.test.expect
+++ b/zsh/userinput.test.expect
@@ -2,7 +2,7 @@
 set timeout 10
 
 spawn zsh "-i";
-expect "❯";
+expect ">"
 
 # Clear up input with ctrl-w
 send "\x17";
@@ -14,9 +14,19 @@ expect "*"
 send "source ~/.zshrc\r";
 
 expect {
-  ":*:*\r" {puts "Found possible errors in output"; exit 1}
-  "compinit: initialization aborted";
-  expect "❯";
+    # Wants to catch:
+    # sh:1: url-quote-magic: function definition file not found
+    # Handle a shell error about missing function definition files
+    "sh:*:*\r" {
+        puts "Found possible errors in output"
+        exit 1
+    }
+    # Handle Zsh's compinit error
+    "compinit: initialization aborted" {
+        puts "Compinit initialization failed"
+        exit 1
+    }
+    ">"
 }
 
 # Clear up input with ctrl-w
@@ -35,7 +45,3 @@ if {$os_error_flag == 0} {
     puts "errno: $value"
     exit $value
 }
-EOF
-echo "spawned process status" $?
-rm -f $tmp_script_file
-echo "done"

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -27,12 +27,6 @@ fi
 autoload -U start-ssh-and-add-identity
 start-ssh-and-add-identity
 
-# TODO(kaihowl) investigate failure / blocker on CI
-if [[ -z ${CI} ]]; then
-  autoload -U start-gcm-helper
-  start-gcm-helper
-fi
-
 # Periodically (typically once a day), update from github
 source "$DOTS/script/check_for_upgrade.sh"
 


### PR DESCRIPTION
Only runs on macOS. Did not spend more time on figuring out the
flakyness on Ubuntu.

Includes a couple robustness improvements.

topic:fixzsh-reenable-zsh-test