### PR TITLE
fix(zsh): remove unnecessary ZSH_AUTOSUGGEST_MANUAL_REBIND

### DIFF
--- a/zsh/autosuggestions.zsh
+++ b/zsh/autosuggestions.zsh
@@ -1,5 +1,2 @@
-# TODO(kaihowl) double check effect and use
-# shellcheck disable=SC2034
-ZSH_AUTOSUGGEST_MANUAL_REBIND=1
 # shellcheck disable=SC1090
 source ~/.nix-profile/share/zsh-autosuggestions/zsh-autosuggestions.zsh


### PR DESCRIPTION
The performance hit the rebinding widgets imposes, is not observable by
me. I have _not_ benchmarked this, yet I did not notice any difference
in day-to-day usage. Also with zprof, I could not spot the function in
which this parameter is used.

Removed to clean up config.

topic:fixzsh-remove-unnecessary-zshautosuggestmanualrebind