### PR TITLE
chore: remove reattach-to-user-namespace

### DIFF
--- a/bin/safe-reattach-to-user-namespace
+++ b/bin/safe-reattach-to-user-namespace
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-# Source: https://github.com/jimeh/dotfiles/commit/3838db8
-# If reattach-to-user-namespace is not available, just run the command.
-if [ -n "$(command -v reattach-to-user-namespace)" ]; then
-  reattach-to-user-namespace "$@"
-else
-  exec "$@"
-fi

--- a/home.nix
+++ b/home.nix
@@ -64,8 +64,7 @@ minimal-packages = with pkgs; [
       pkgs-unstable.ncdu
       flock
     ]
-    # TODO(kaihowl) Double check if reattach-to-user-namespace is still needed
-    ++ (lib.optionals pkgs.stdenv.isDarwin [reattach-to-user-namespace coreutils])
+    ++ (lib.optional pkgs.stdenv.isDarwin coreutils)
     # need up to date ssh-keygen for newer git version and signing of commits
     ++ (lib.optional pkg.stdenv.isLinux openssh)
     ;


### PR DESCRIPTION
This functionality is incorporated into tmux since version 2.6
according to https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard.

Remove the workarounds.

topic:chore-remove-reattach-to-user-namespace