### PR TITLE
refactor(nix): move license check into separate attribute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ full:
 minimal:
 	nix run --impure .#home-manager -- --impure switch --flake .#minimal
 
+checklicenses:
+	nix flake check --impure 
+
 clean:
 	nix-collect-garbage -d
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
   };
 
   outputs = { nixpkgs, home-manager, nixpkg-unstable, nixpkgs-prev, ... }:
-    let results = let
+    let
       lib = nixpkgs.lib;
       lic = import ./lic.nix;
       # https://github.com/NixOS/nix/issues/3978#issuecomment-1676001388
@@ -51,5 +51,7 @@
       licenses = rec {
         badDeps = (lic.keepBadDeps homeConfigurations.full.config.home.packages);
       };
-    }; in assert results.licenses.badDeps == []; results;
+
+      checks.${system}.licenses =  assert licenses.badDeps == []; pkgs.runCommand "nop" {} "mkdir $out/";
+    };
 }

--- a/script/test
+++ b/script/test
@@ -35,3 +35,6 @@ if [[ $failed_tests -ne 0 ]]; then
     echo "FOUND ${failed_tests} FAILED TESTS"
     exit 1
 fi
+
+# check nix licenses
+nix flake check --impure 


### PR DESCRIPTION
Only run this as part of CI once.

topic: refactornix-move-license-check-into-separate-attribute