### PR TITLE
fix(zsh): only enter zsh from bash when interactive

### DIFF
--- a/zsh/install.sh
+++ b/zsh/install.sh
@@ -32,7 +32,8 @@ source "$SCRIPT_DIR/../common/utilities.sh"
 nixzsh=$(which zsh)
 
 touch ~/.bash_profile
-sed_replace_in_file ~/.bash_profile "# fail-safe exec" "${nixzsh} --version >/dev/null && SHELL=${nixzsh} exec ${nixzsh} # fail-safe exec"
+# Only run if interactive shell
+sed_replace_in_file ~/.bash_profile "# fail-safe exec" "nixzsh=$nixzsh bindmount=$SCRIPT_DIR/../bin/nix-bindmount source $SCRIPT_DIR/start-zsh # fail-safe exec"
 
 touch ~/.zprofile
 sed_replace_in_file ~/.zprofile "# fail-safe exec" "[[ \$SHELL != $nixzsh ]] && ${nixzsh} --version >/dev/null && SHELL=${nixzsh} exec ${nixzsh} # fail-safe exec"

--- a/zsh/start-zsh
+++ b/zsh/start-zsh
@@ -1,0 +1,12 @@
+# For bash, when interactive shell, then replace by nix-zsh
+# Optionally, if there is a user-local ~/.nix folder, restore the bind mount
+
+if [[ $- == *i* ]]; then
+  if [[ -d ~/.nix ]]; then
+    if ! [[ -d /nix ]]; then
+      $bindmount
+    fi
+  fi
+
+  ${nixzsh} --version >/dev/null && SHELL=${nixzsh} exec ${nixzsh};
+fi


### PR DESCRIPTION
topic:fixzsh-only-enter-zsh-from-bash-when-interactive