### PR TITLE
fix: no login shell for tests

### DIFF
--- a/script/test
+++ b/script/test
@@ -25,7 +25,7 @@ fi
 failed_tests=0
 for t in "${tests[@]}"; do
   printf "Running \e[32m%s\e[0m\n" "${t}"
-  if ! timeout 60s zsh -i -l "${t}"; then
+  if ! timeout 60s zsh -i "${t}"; then
       echo "ERROR: TEST ${t} FAILED"
       ((failed_tests+=1))
   fi

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -20,8 +20,6 @@ fi
 
 fpath=($DOTS/zsh $fpath)
 
-# hotfix for #939
-unset __ETC_PROFILE_NIX_SOURCED
 if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
   . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
 fi


### PR DESCRIPTION
For #939, we cannot use a login shell as the nix daemon script putting the profile bin directory in front of everything else in the PATH will already have run once and exported the env var to prevent duplicated running. Running as a login shell for tests will only run the macOS specific helpers to put system binaries in front of the PATH again. This ultimately will mean that for a nested login shell, the system path libraries will precede the nix installed ones.