### PR TITLE
fix(zsh): `which` test should not print full function definition

### DIFF
--- a/virtualenvwrapper/test.sh
+++ b/virtualenvwrapper/test.sh
@@ -21,7 +21,7 @@ if ! mkvirtualenv --help; then
 fi
 
 echo "Check if 'workon' is available"
-if ! which workon; then
+if ! which workon > /dev/null; then
   echo "Failed to find workon";
   exit 1
 fi


### PR DESCRIPTION
The function for `workon` contains `error:` which we pick up as an
error in the CI output.

topic:fixzsh-which-test-should-not-print-full-function-definition

- [x] check that output is gone from CI