### PR TITLE
feat(zsh): prevent customization in cursor prompts

### DIFF
--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -7,6 +7,11 @@ if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
   . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
 fi
 
+# Do not apply any customization when running in cursor prompts
+if [[ -n $PAGER ]] && [[ -n $CURSOR_TRACE_ID ]]; then
+  return
+fi
+
 # Ensure running in tmux, but skip if running in Cursor, VS Code, or IntelliJ
 if [[ ! -v TMUX ]] && [[ -z $CI ]] && [[ -z $CURSOR ]] && [[ -z $VSCODE_PID ]] && [[ -z $INTELLIJ_TERMINAL ]] && [[ -z $TERM_PROGRAM ]]; then
   tmux new-session -s "$(hostname -f)_dev.$$"


### PR DESCRIPTION
Added a condition to skip zsh customizations when running in cursor prompts, ensuring a smoother experience in environments like VS Code and IntelliJ.

topic:featzsh-prevent-customization-in-cursor-prompts