### PR TITLE
refactor(nvim): move common code to top for omnifunc function

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -185,13 +185,14 @@ nnoremap <leader>c /\m\(<<<<<<< \\|=======\n\\|>>>>>>> \)<cr>
 
 "{{{ omnifunc for revup topic
 function! OmniTopicSlug(findstart, base)
+  " Always handle findstart at the start of the function
+  if a:findstart
+    return col('.')
+  endif
+
   " Get the current line and determine behavior based on its prefix
   let l:current_line = getline('.')
   if l:current_line =~# '^topic:'
-    if a:findstart
-      " Return the start position for completion
-      return col('.')
-    endif
 
     " Get the first line of the file
     let l:first_line = getline(1)
@@ -212,11 +213,6 @@ function! OmniTopicSlug(findstart, base)
     " Return the slug for completion output
     return [l:slug]
   elseif l:current_line =~# '^relative:'
-    if a:findstart
-      " Return the start position for completion
-      return col('.')
-    endif
-
     " Call external command to list topics
     let l:topics = split(system('revup toolkit list-topics'), '\n')
     return l:topics


### PR DESCRIPTION
Accept behavior change for Rhubarb to not be called for findstart
anymore.

topic:refactornvim-move-common-code-to-top-for-omnifunc-function