### PR TITLE
fix: disable version reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,19 +78,19 @@ jobs:
           export NIX_CONFIG="access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
           cd .dotfiles/
           ./script/ci.sh
-      - name: Rename versions report
-        if: always()
-        run: |
-          cd .dotfiles/
-          mv versions.txt versions-${{matrix.os}}-${{matrix.profile}}.txt
-      - name: Archive version report
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          include-hidden-files: true
-          name: versions-report-${{matrix.os}}-${{matrix.profile}}
-          path: .dotfiles/versions-*.txt
-          if-no-files-found: error
+      # - name: Rename versions report
+      #   if: always()
+      #   run: |
+      #     cd .dotfiles/
+      #     mv versions.txt versions-${{matrix.os}}-${{matrix.profile}}.txt
+      # - name: Archive version report
+      #   uses: actions/upload-artifact@v4
+      #   if: always()
+      #   with:
+      #     include-hidden-files: true
+      #     name: versions-report-${{matrix.os}}-${{matrix.profile}}
+      #     path: .dotfiles/versions-*.txt
+      #     if-no-files-found: error
   report:
     name: git-perf
     needs: build

--- a/script/versions.sh
+++ b/script/versions.sh
@@ -8,18 +8,10 @@ fi
 output_file=$1
 echo "output to $output_file"
 
-echo "" > "$output_file"
-
-# TODO use nix-env reporting
-
 # Need to have proper PATH
 if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
   # shellcheck disable=SC1091
   . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
 fi
 
-tmp_file=$(mktemp)
-trap 'rm -rf $tmp_file' EXIT
-nvim --headless "+PlugSnapshot! $tmp_file" +qall
-
-{ echo "nvim plugins installed:"; cat "$tmp_file"; } >> "$output_file"
+# TODO use nix-env reporting


### PR DESCRIPTION
The reporting of vim plugins was broken since the switch to nix. With
statically determined versions, there is no need to report versions in
the first place.

topic:kaihowlstack-fix-disable-version-reporting