### PR TITLE
feat(nvim): use a different separator for the branch topic name

### DIFF
--- a/nvim/config--nvim--init.vim.symlink
+++ b/nvim/config--nvim--init.vim.symlink
@@ -213,7 +213,7 @@ function! OmniTopicSlug(findstart, base)
 
     " If branch name is not empty, prepend it with a dash to the slug
     if !empty(l:branch)
-      let l:slug = s:make_slug(l:branch) . '-' . l:slug
+      let l:slug = s:make_slug(l:branch) . '_' . l:slug
     endif
 
     " Return the slug for completion output


### PR DESCRIPTION
topic:kaihowlstack_featnvim-use-a-different-separator-for-the-branch-topic-name