### PR TITLE
Update git-perf GitHub Action to v0.18.0 in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
           path: '.dotfiles'
           fetch-depth: 40
       - name: Install git-perf
-        uses: kaihowl/git-perf/.github/actions/install@latest
+        uses: kaihowl/git-perf/.github/actions/install@v0.18.0
       - run: |
           cd .dotfiles/
           git config --global user.email "git-perf@example.com"
@@ -95,7 +95,7 @@ jobs:
     name: git-perf
     if: always()
     needs: build
-    uses: kaihowl/git-perf/.github/workflows/report.yml@latest
+    uses: kaihowl/git-perf/.github/workflows/report.yml@v0.18.0
     with:
       additional-args: '-s os'
       concurrency-token: gh-pages-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
           path: '.dotfiles'
           fetch-depth: 40
       - name: Install git-perf
-        uses: kaihowl/git-perf/.github/actions/install@v0.18.0
+        uses: kaihowl/git-perf/.github/actions/install@git-perf-v0.18.0
       - run: |
           cd .dotfiles/
           git config --global user.email "git-perf@example.com"
@@ -95,7 +95,7 @@ jobs:
     name: git-perf
     if: always()
     needs: build
-    uses: kaihowl/git-perf/.github/workflows/report.yml@v0.18.0
+    uses: kaihowl/git-perf/.github/workflows/report.yml@git-perf-v0.18.0
     with:
       additional-args: '-s os'
       concurrency-token: gh-pages-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Upgrades the `git-perf` GitHub Action usage from `latest` to fixed version `v0.18.0` in the test workflow
- Ensures more stable and reproducible workflow execution by pinning git-perf versions

## Changes

### CI Workflow Updates
- `.github/workflows/test.yml`:
  - Changed git-perf install action from `latest` to `v0.18.0`
  - Updated git-perf report workflow usage from `latest` to `v0.18.0`

## Test plan
- [x] Confirm GitHub Actions workflows trigger and run successfully with updated git-perf version
- [x] Verify git-perf install and report steps complete without errors
- [x] Check for consistent and expected performance reporting in CI logs

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e39010f7-4be6-4e6a-aa76-726269de178e